### PR TITLE
Compatibility with SDK PR #91

### DIFF
--- a/driver/normalizer/normalizer.go
+++ b/driver/normalizer/normalizer.go
@@ -20,7 +20,6 @@ https://greentreesnakes.readthedocs.io/en/latest/nodes.html
 
  */
 
- // TODO: all the "orelse" subnodes of for/while/try as "IfElse" childs
  // TODO: add the "stride", third element of slices in some way once we've the index/slice roles
 var AnnotationRules = On(Any).Self(
 	On(Not(HasInternalType(pyast.Module))).Error("root must be Module"),
@@ -83,7 +82,6 @@ var AnnotationRules = On(Any).Self(
 		// with a body that is a list of StringLiteral + FormattedValue(value, conversion, format_spec)
 		On(HasInternalType(pyast.JoinedStr)).Roles(StringLiteral),
 		On(HasInternalType(pyast.NoneLiteral)).Roles(NullLiteral),
-		// FIXME: change these to ContainerLiteral/CompoundLiteral/whatever if they're added
 		On(HasInternalType(pyast.Set)).Roles(SetLiteral),
 		On(HasInternalType(pyast.List)).Roles(ListLiteral),
 		On(HasInternalType(pyast.Dict)).Roles(MapLiteral).Children(
@@ -220,19 +218,16 @@ var AnnotationRules = On(Any).Self(
 			On(HasInternalRole("target")).Roles(ForUpdate),
 			On(HasInternalType("For.orelse")).Roles(IfElse),
 		),
-		// FIXME: while internal keys: body -> WhileBody, orelse -> ?, test -> WhileCondition
 		On(HasInternalType(pyast.While)).Roles(While).Children(
 			On(HasInternalType("While.body")).Roles(WhileBody),
 			On(HasInternalRole("test")).Roles(WhileCondition),
 			On(HasInternalType("While.orelse")).Roles(IfElse),
 		),
-		// FIXME: detect qualified 'Call.func' with a "Call.func.value" member and
 		On(HasInternalType(pyast.Pass)).Roles(Noop),
 		On(HasInternalType(pyast.Num)).Roles(NumberLiteral),
 		// FIXME: this is the annotated assignment (a: annotation = 3) not exactly Assignment
 		// it also lacks AssignmentValue and AssignmentVariable (see how to add them)
 		On(HasInternalType(pyast.AnnAssign)).Roles(Assignment),
-		// FIXME: this is the a += 1 style assigment
 		On(HasInternalType(pyast.AugAssign)).Roles(Assignment),
 		On(HasInternalType(pyast.Assert)).Roles(Assert),
 

--- a/driver/normalizer/normalizer_test.go
+++ b/driver/normalizer/normalizer_test.go
@@ -30,7 +30,7 @@ func TestAnnotate(t *testing.T) {
 	require.NoError(err)
 
 	missingRole := make(map[string]bool)
-	iter := uast.NewPreOrderPathIter(uast.NewPath(n))
+	iter := uast.NewOrderPathIter(uast.NewPath(n))
 	for {
 		n := iter.Next()
 		if n.IsEmpty() {

--- a/driver/normalizer/tonoder.go
+++ b/driver/normalizer/tonoder.go
@@ -22,6 +22,14 @@ var NativeToNoder = &uast.BaseToNoder{
 	SyntheticTokens: map[string]string{
 		"Print"   : "print",
 		"Ellipsis": "PythonEllipsisOperator",
+		"Add"     : "+",
+		"Sub"     : "-",
+		"Mult"    : "*",
+		"Div"     : "/",
+		"FloorDiv": "//",
+		"Mod"     : "%",
+		"Pow"     : "^",
+		"AugAssign": "?=",
 	},
 	PromoteAllPropertyLists: false,
 	PromotedPropertyLists: map[string]map[string]bool {


### PR DESCRIPTION
- Remove old comments that don't apply anymore
- Add syntheticTokens for Python operators since they were being assigned Roles but not Tokens (caveat: currently at least for the Python driver SyntheticTokens doesn't seem to work, investigating it).
- Renamed NewPreOrderPathIter to NewOrderPathIter to make it compatible with the [SDK #91](https://github.com/bblfsh/sdk/pull/91)
