### PR TITLE
Move response metadata into the metadata key

### DIFF
--- a/native/python_package/python_driver/requestprocessor.py
+++ b/native/python_package/python_driver/requestprocessor.py
@@ -156,10 +156,12 @@ class RequestProcessor(metaclass=abc.ABCMeta):
             response = Response({
                 'status'           : 'ok',
                 'errors'           : self.errors,
-                'language'         : 'python',
-                'language_version' : version,
-                'driver'           : 'python23:%s' % __version__,
                 'ast'              : ast,
+                'metadata'         : {
+                    'language'         : 'python',
+                    'language_version' : version,
+                    'driver'           : 'python23:%s' % __version__,
+                }
             })
             if filepath:
                 response['filepath'] = filepath

--- a/native/python_package/test/test_python_driver.py
+++ b/native/python_package/test/test_python_driver.py
@@ -143,7 +143,6 @@ class Test10ProcessRequestFunc(TestPythonDriverBase):
 
     def _check_reply_dict(self, response: Response, has_errors: bool=False) -> None:
         self.assertIsInstance(response, dict)
-        self.assertEqual(response.get('driver'), 'python23:%s' % __version__)
         status = response.get('status')
 
         if has_errors:
@@ -152,10 +151,10 @@ class Test10ProcessRequestFunc(TestPythonDriverBase):
             self.assertIsInstance(errors, list)
             self.assertGreater(len(errors), 0)
         else:
-            self.assertEqual(response.get('language'), 'python')
+            self.assertEqual(response['metadata']['language'], 'python')
             self.assertEqual(status, 'ok')
             self._check_AST_dict(response)
-            language_version = response.get('language_version', -1)
+            language_version = response['metadata'].get('language_version', -1)
             assert str(language_version) in ('2', '3')
 
     def _check_AST_dict(self, response: Response) -> None:


### PR DESCRIPTION
Includes language, language_version and driver of the parser response into the "metadata" field to match the latest spec.