### PR TITLE
Changed Docker image to alpine:3.6

### DIFF
--- a/Dockerfile.build.tpl
+++ b/Dockerfile.build.tpl
@@ -1,9 +1,9 @@
-FROM python:3.6-alpine
+FROM alpine:3.6
 
 RUN mkdir -p /opt/driver/src && \
     adduser $BUILD_USER -u $BUILD_UID -D -h /opt/driver/src
 
-RUN apk add --no-cache --update python py-pip git build-base bash
+RUN apk add --no-cache --update python python-dev python3 python3-dev py-pip py2-pip git build-base bash
 RUN pip3 install six git+https://github.com/juanjux/python-pydetector.git \
     git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
 RUN pip2 install six git+https://github.com/juanjux/python-pydetector.git

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -1,7 +1,7 @@
-FROM python:3.6-alpine
+FROM alpine:3.6
 MAINTAINER source{d}
 
-RUN apk add --no-cache --update python py-pip git
+RUN apk add --no-cache --update python python3 py-pip py2-pip git
 RUN pip3 install six git+https://github.com/juanjux/python-pydetector.git
 RUN pip2 install six git+https://github.com/juanjux/python-pydetector.git
 

--- a/native/python_package/python_driver/requestprocessor.py
+++ b/native/python_package/python_driver/requestprocessor.py
@@ -156,10 +156,12 @@ class RequestProcessor(metaclass=abc.ABCMeta):
             response = Response({
                 'status'           : 'ok',
                 'errors'           : self.errors,
-                'language'         : 'python',
-                'language_version' : version,
-                'driver'           : 'python23:%s' % __version__,
                 'ast'              : ast,
+                'metadata'         : {
+                    'language'         : 'python',
+                    'language_version' : version,
+                    'driver'           : 'python23:%s' % __version__,
+                }
             })
             if filepath:
                 response['filepath'] = filepath

--- a/native/python_package/test/test_alpine.sh
+++ b/native/python_package/test/test_alpine.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-time sh -c './sendmsg.py /usr/lib/python2.7/*.py | docker run -i --name python_driver --rm python_driver_alpine:latest > /dev/null'
+# Alpine 3.6:
+time sh -c './sendmsg.py /usr/lib/python2.7/*.py | docker run -i --name python_driver --rm 1edcc008c3f6 /opt/driver/bin/native > /dev/null'

--- a/native/python_package/test/test_python_driver.py
+++ b/native/python_package/test/test_python_driver.py
@@ -143,7 +143,6 @@ class Test10ProcessRequestFunc(TestPythonDriverBase):
 
     def _check_reply_dict(self, response: Response, has_errors: bool=False) -> None:
         self.assertIsInstance(response, dict)
-        self.assertEqual(response.get('driver'), 'python23:%s' % __version__)
         status = response.get('status')
 
         if has_errors:
@@ -152,10 +151,10 @@ class Test10ProcessRequestFunc(TestPythonDriverBase):
             self.assertIsInstance(errors, list)
             self.assertGreater(len(errors), 0)
         else:
-            self.assertEqual(response.get('language'), 'python')
+            self.assertEqual(response['metadata']['language'], 'python')
             self.assertEqual(status, 'ok')
             self._check_AST_dict(response)
-            language_version = response.get('language_version', -1)
+            language_version = response['metadata'].get('language_version', -1)
             assert str(language_version) in ('2', '3')
 
     def _check_AST_dict(self, response: Response) -> None:


### PR DESCRIPTION
- The images use 33MB less.
- Performance is similar.
- Comes with Python 3.6 by default so we don't have to use an alpine variant anymore.