### PR TITLE
Fixed pip install versions of pydetector, upgraded dependency to new …

### DIFF
--- a/Dockerfile.build.tpl
+++ b/Dockerfile.build.tpl
@@ -4,8 +4,8 @@ RUN mkdir -p /opt/driver/src && \
     adduser $BUILD_USER -u $BUILD_UID -D -h /opt/driver/src
 
 RUN apk add --no-cache --update python python-dev python3 python3-dev py-pip py2-pip git build-base bash
-RUN pip3 install six git+https://github.com/juanjux/python-pydetector.git \
+RUN pip3 install six pydetector==0.5.7 \
     git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
-RUN pip2 install six git+https://github.com/juanjux/python-pydetector.git
+RUN pip2 install six pydetector==0.5.7
 
 WORKDIR /opt/driver/src

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -2,8 +2,8 @@ FROM alpine:3.6
 MAINTAINER source{d}
 
 RUN apk add --no-cache --update python python3 py-pip py2-pip git
-RUN pip3 install six git+https://github.com/juanjux/python-pydetector.git
-RUN pip2 install six git+https://github.com/juanjux/python-pydetector.git
+RUN pip3 install six pydetector==0.5.7
+RUN pip2 install six pydetector==0.5.7
 
 ADD build /opt/driver/bin
 ADD native/python_package /tmp/python_driver

--- a/native/python_package/requirements.txt
+++ b/native/python_package/requirements.txt
@@ -1,4 +1,4 @@
 msgpack-python==0.4.8
-pydetector==0.5.5
+pydetector==0.5.7
 -e git+git://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
 typed-ast==1.0.1

--- a/native/python_package/setup.py
+++ b/native/python_package/setup.py
@@ -32,7 +32,7 @@ setup(
     },
     install_requires=[
         "msgpack-python==0.4.8",
-        "pydetector==0.5.5"
+        "pydetector==0.5.7"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
- pip install commands for pydetector from pypi instead of Github
- Set specific version of dependency 
- Upgrade dependency to 0.5.7 (Apache 2.0)