### PR TITLE
Fix/more simpleidentifier

### DIFF
--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -165,7 +165,7 @@ var AnnotationRules = On(Any).Self(
 		// FIXME: the FunctionDeclarationReceiver is not set for methods; it should be taken from the parent
 		// Type node Token (2 levels up) but the SDK doesn't allow this
 		// TODO: create an issue for the SDK
-		On(HasInternalType(pyast.FunctionDef)).Roles(FunctionDeclaration, FunctionDeclarationName).Children(
+		On(HasInternalType(pyast.FunctionDef)).Roles(FunctionDeclaration, FunctionDeclarationName, SimpleIdentifier).Children(
 			On(HasInternalType("FunctionDef.body")).Roles(FunctionDeclarationBody),
 			// FIXME: change to FunctionDeclarationArgumentS once the PR has been merged
 			On(HasInternalType("arguments")).Roles(FunctionDeclarationArgument).Children(
@@ -194,7 +194,7 @@ var AnnotationRules = On(Any).Self(
 			On(HasInternalRole("func")).Self(On(HasInternalRole("id"))).Roles(CallCallee),
 			On(HasInternalRole("func")).Self(On(HasInternalRole("attr"))).Roles(CallCallee),
 			On(HasInternalRole("func")).Self(On(HasInternalType(pyast.Attribute))).Children(
-				On(HasInternalRole("id")).Roles(CallReceiver),
+				On(HasInternalRole("id")).Roles(CallReceiver, SimpleIdentifier),
 			),
 		),
 
@@ -280,8 +280,8 @@ var AnnotationRules = On(Any).Self(
 		On(HasInternalType(pyast.IfExp)).Roles(If),
 		On(HasInternalType(pyast.Import)).Roles(ImportDeclaration),
 		On(HasInternalType(pyast.ImportFrom)).Roles(ImportDeclaration),
-		On(HasInternalType(pyast.Alias)).Roles(ImportAlias),
-		On(HasInternalType(pyast.ClassDef)).Roles(TypeDeclaration).Children(
+		On(HasInternalType(pyast.Alias)).Roles(ImportAlias, SimpleIdentifier),
+		On(HasInternalType(pyast.ClassDef)).Roles(TypeDeclaration, SimpleIdentifier).Children(
 			On(HasInternalType("ClassDef.body")).Roles(TypeDeclarationBody),
 			On(HasInternalType("ClassDef.bases")).Roles(TypeDeclarationBases),
 		),
@@ -313,7 +313,7 @@ var AnnotationRules = On(Any).Self(
 		),
 		// Repr already comes as a Call \o/
 		// Print as a function too.
-		On(HasInternalType(pyast.Print)).Roles(Call, CallCallee).Children(
+		On(HasInternalType(pyast.Print)).Roles(Call, CallCallee, SimpleIdentifier).Children(
 			On(HasInternalRole("dest")).Roles(CallPositionalArgument),
 			On(HasInternalRole("nl")).Roles(CallPositionalArgument),
 			On(HasInternalRole("values")).Roles(CallPositionalArgument).Children(
@@ -346,6 +346,5 @@ var AnnotationRules = On(Any).Self(
 				On(HasInternalRole("left")).Roles(BinaryExpressionLeft),
 			),
 		),
-
 	),
 )

--- a/tests/classdef.py.uast
+++ b/tests/classdef.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: ClassDef {
-.  .  .  Roles: TypeDeclaration
+.  .  .  Roles: TypeDeclaration,SimpleIdentifier
 .  .  .  TOKEN "Animal"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -28,7 +28,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: FunctionDef {
-.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "__init__"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0
@@ -165,7 +165,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: FunctionDef {
-.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "method"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0
@@ -265,7 +265,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: FunctionDef {
-.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "a"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0
@@ -386,7 +386,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  3: FunctionDef {
-.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  .  .  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "a"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0

--- a/tests/classdef_inheritance.py.uast
+++ b/tests/classdef_inheritance.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: ClassDef {
-.  .  .  Roles: TypeDeclaration
+.  .  .  Roles: TypeDeclaration,SimpleIdentifier
 .  .  .  TOKEN "Dog"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -60,7 +60,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: ClassDef {
-.  .  .  Roles: TypeDeclaration
+.  .  .  Roles: TypeDeclaration,SimpleIdentifier
 .  .  .  TOKEN "RobotDog"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/classdef_metaclass_py2.py.uast
+++ b/tests/classdef_metaclass_py2.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: ClassDef {
-.  .  .  Roles: TypeDeclaration
+.  .  .  Roles: TypeDeclaration,SimpleIdentifier
 .  .  .  TOKEN "MySingleton"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/classdef_metaclass_py3.py.uast
+++ b/tests/classdef_metaclass_py3.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: ClassDef {
-.  .  .  Roles: TypeDeclaration
+.  .  .  Roles: TypeDeclaration,SimpleIdentifier
 .  .  .  TOKEN "MySingleton"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -70,7 +70,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: ClassDef {
-.  .  .  Roles: TypeDeclaration
+.  .  .  Roles: TypeDeclaration,SimpleIdentifier
 .  .  .  TOKEN "MySingleton"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_annotated.py.uast
+++ b/tests/functiondef_annotated.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_decorated.py.uast
+++ b/tests/functiondef_decorated.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -76,7 +76,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_defaultparams.py.uast
+++ b/tests/functiondef_defaultparams.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_docstring.py.uast
+++ b/tests/functiondef_docstring.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_kwarg.py.uast
+++ b/tests/functiondef_kwarg.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -94,7 +94,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someVarMapFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_simple.py.uast
+++ b/tests/functiondef_simple.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -118,7 +118,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someGen"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/functiondef_vararg.py.uast
+++ b/tests/functiondef_vararg.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "someFunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/import.py.uast
+++ b/tests/import.py.uast
@@ -26,7 +26,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: alias {
-.  .  .  .  .  .  .  Roles: ImportAlias
+.  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  asname: <nil>
@@ -53,14 +53,14 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: alias {
-.  .  .  .  .  .  .  Roles: ImportAlias
+.  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: alias {
-.  .  .  .  .  .  .  Roles: ImportAlias
+.  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "os"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  asname: <nil>
@@ -89,7 +89,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: alias {
-.  .  .  .  .  .  .  Roles: ImportAlias
+.  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "path"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  asname: <nil>
@@ -118,14 +118,14 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: alias {
-.  .  .  .  .  .  .  Roles: ImportAlias
+.  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "join"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: alias {
-.  .  .  .  .  .  .  Roles: ImportAlias
+.  .  .  .  .  .  .  Roles: ImportAlias,SimpleIdentifier
 .  .  .  .  .  .  .  TOKEN "exists"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  asname: <nil>

--- a/tests/pass.py.uast
+++ b/tests/pass.py.uast
@@ -36,7 +36,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "somefun"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -109,7 +109,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  2: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "otherfun"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/print.py.uast
+++ b/tests/print.py.uast
@@ -10,7 +10,7 @@ Module {
 .  }
 .  Children: {
 .  .  0: Print {
-.  .  .  Roles: Call,CallCallee
+.  .  .  Roles: Call,CallCallee,SimpleIdentifier
 .  .  .  TOKEN "print"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
@@ -39,7 +39,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: Print {
-.  .  .  Roles: Call,CallCallee
+.  .  .  Roles: Call,CallCallee,SimpleIdentifier
 .  .  .  TOKEN "print"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0

--- a/tests/string_fstring.py.uast
+++ b/tests/string_fstring.py.uast
@@ -558,7 +558,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  7: FunctionDef {
-.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName
+.  .  .  Roles: FunctionDeclaration,FunctionDeclarationName,SimpleIdentifier
 .  .  .  TOKEN "somefunc"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0


### PR DESCRIPTION
I had a wrong concept of the SimpleIdentifier role, this PR fixes it adding it to some nodes that should also have it like FunctionDef and CallCalee. 