### PR TITLE
Revised requirements

### DIFF
--- a/Dockerfile.build.tpl
+++ b/Dockerfile.build.tpl
@@ -4,8 +4,7 @@ RUN mkdir -p /opt/driver/src && \
     adduser $BUILD_USER -u $BUILD_UID -D -h /opt/driver/src
 
 RUN apk add --no-cache --update python python-dev python3 python3-dev py-pip py2-pip git build-base bash
-RUN pip3 install six pydetector==0.6.1 \
+RUN pip3 install pydetector-bblfsh==0.10.3 \
     git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
-RUN pip2 install six pydetector==0.6.1
 
 WORKDIR /opt/driver/src

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -2,8 +2,8 @@ FROM alpine:3.6
 MAINTAINER source{d}
 
 RUN apk add --no-cache --update python python3 py-pip py2-pip git
-RUN pip3 install six pydetector==0.6.1
-RUN pip2 install six pydetector==0.6.1
+
+RUN pip2 install pydetector-bblfsh==0.10.3
 
 ADD build /opt/driver/bin
 ADD native/python_package /tmp/python_driver

--- a/native/python_package/requirements.txt
+++ b/native/python_package/requirements.txt
@@ -1,3 +1,2 @@
 pydetector-bblfsh==0.10.3
--e git+git://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
-typed-ast==1.0.1
+//github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy


### PR DESCRIPTION
Needed as part of: https://github.com/bblfsh/python-driver/issues/41

- Upgraded pydetector for Python 2 too.
- Removed unneeded pydetector install at the build stage.
- Removed unneeded "six" install; already installed by pydetector
- Removed unneeded typed-ast install; already installed by mypy

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>