### PR TITLE
Use a local copy of pydetector if it exists

### DIFF
--- a/Dockerfile.build.tpl
+++ b/Dockerfile.build.tpl
@@ -4,7 +4,6 @@ RUN mkdir -p /opt/driver/src && \
     adduser $BUILD_USER -u $BUILD_UID -D -h /opt/driver/src
 
 RUN apk add --no-cache --update python python-dev python3 python3-dev py-pip py2-pip git build-base bash
-RUN pip3 install pydetector-bblfsh==0.10.3 \
-    git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
+RUN pip3 install git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
 
 WORKDIR /opt/driver/src

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -3,11 +3,15 @@ MAINTAINER source{d}
 
 RUN apk add --no-cache --update python python3 py-pip py2-pip git
 
-RUN pip2 install pydetector-bblfsh==0.10.3
 
 ADD build /opt/driver/bin
 ADD native/python_package /tmp/python_driver
 RUN pip3 install /tmp/python_driver
 RUN yes|rm -rf /tmp/python_driver
+
+ADD native/dev_deps /tmp/dev_deps
+RUN pip2 install -U /tmp/dev_deps/python-pydetector || pip2 install pydetector-bblfsh==0.10.3
+RUN pip3 install -U /tmp/dev_deps/python-pydetector || pip3 install pydetector-bblfsh==0.10.3
+RUN yes|rm -rf /tmp/dev_deps
 
 CMD /opt/driver/bin/driver

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -1,17 +1,22 @@
 FROM alpine:3.6
 MAINTAINER source{d}
 
-RUN apk add --no-cache --update python python3 py-pip py2-pip git
+ARG DEVDEPS=native/dev_deps
+ARG CONTAINER_DEVDEPS=/tmp/dev_deps
+ARG PYDETECTOR_VER=0.10.3
 
+RUN apk add --no-cache --update python python3 py-pip py2-pip git
 
 ADD build /opt/driver/bin
 ADD native/python_package /tmp/python_driver
 RUN pip3 install /tmp/python_driver
 RUN yes|rm -rf /tmp/python_driver
 
-ADD native/dev_deps /tmp/dev_deps
-RUN pip2 install -U /tmp/dev_deps/python-pydetector || pip2 install pydetector-bblfsh==0.10.3
-RUN pip3 install -U /tmp/dev_deps/python-pydetector || pip3 install pydetector-bblfsh==0.10.3
-RUN yes|rm -rf /tmp/dev_deps
+ADD ${DEVDEPS} ${CONTAINER_DEVDEPS}
+ENV ENV_DEVDEPS=${DEVDEPS}
+ENV ENV_PYDETECTOR_VER=${PYDETECTOR_VER}
+RUN pip2 install -U ${CONTAINER_DEVDEPS}/python-pydetector || pip2 install pydetector-bblfsh==${PYDETECTOR_VER}
+RUN pip3 install -U ${CONTAINER_DEVDEPS}/python-pydetector || pip3 install pydetector-bblfsh==${PYDETECTOR_VER}
+RUN yes|rm -rf ${CONTAINER_DEVDEPS}
 
 CMD /opt/driver/bin/driver

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 test-native-internal:
-	cd native/python_package/test; \
+	pip3 install --user native/dev_deps/python-pydetector/ || pip3 install --user pydetector-bblfsh
+	pip3 install --user git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
+	cd native/python_package/test && \
 	python3 -m unittest discover
 
 build-native-internal:
-	cd native/python_package/; \
+	cd native/python_package/ && \
 	pip3 install -U --user .
 	cp native/sh/native.sh $(BUILD_PATH)/native;
 	chmod +x $(BUILD_PATH)/native

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+DEV_DEPS ?= native/dev_deps
+
 test-native-internal:
-	pip3 install --user native/dev_deps/python-pydetector/ || pip3 install --user pydetector-bblfsh
+	pip3 install --user ${DEV_DEPS}/python-pydetector/ || pip3 install --user pydetector-bblfsh
 	pip3 install --user git+https://github.com/python/mypy.git@0bb2d1680e8b9522108b38d203cb73021a617e64#egg=mypy-lang
 	cd native/python_package/test && \
 	python3 -m unittest discover

--- a/native/dev_deps/README.md
+++ b/native/dev_deps/README.md
@@ -1,0 +1,6 @@
+If a pydetector directory exists here, it will be installed to the driver
+container image instead of the one from PyPI. This way you can test pydetector
+features related to the driver without publishing new versions.
+
+Note that Docker doesn't allow to `ADD` symlinks so the directory
+must be copied, not linked.


### PR DESCRIPTION
For developing and testing pydetector integration with the driver without having to release new versions on PyPI. The directory `native/dev_deps/pydetector` will be installed in the docker image, if it exists, instead of the PyPI version.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>