### PR TITLE
Add synthetic token for Pass

### DIFF
--- a/driver/normalizer/parser.go
+++ b/driver/normalizer/parser.go
@@ -52,6 +52,7 @@ var ToNoder = &native.ObjectToNoder{
 		"UAdd":      "+",
 		"USub":      "-",
 		"Invert":    "~",
+		"Pass":      "pass",
 	},
 	PromoteAllPropertyLists: false,
 	PromotedPropertyLists: map[string]map[string]bool{

--- a/tests/classdef.py.uast
+++ b/tests/classdef.py.uast
@@ -338,6 +338,7 @@ Module {
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 109
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 7

--- a/tests/classdef_inheritance.py.uast
+++ b/tests/classdef_inheritance.py.uast
@@ -64,6 +64,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 23
 .  .  .  .  .  .  .  .  Line: 2
@@ -174,6 +175,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 61
 .  .  .  .  .  .  .  .  Line: 5

--- a/tests/classdef_metaclass_py3.py.uast
+++ b/tests/classdef_metaclass_py3.py.uast
@@ -39,6 +39,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 44
 .  .  .  .  .  .  .  .  Line: 2
@@ -174,6 +175,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 107
 .  .  .  .  .  .  .  .  Line: 5

--- a/tests/functiondef_annotated.py.uast
+++ b/tests/functiondef_annotated.py.uast
@@ -170,6 +170,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 63
 .  .  .  .  .  .  .  .  Line: 2

--- a/tests/functiondef_defaultparams.py.uast
+++ b/tests/functiondef_defaultparams.py.uast
@@ -203,6 +203,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 66
 .  .  .  .  .  .  .  .  Line: 2

--- a/tests/functiondef_docstring.py.uast
+++ b/tests/functiondef_docstring.py.uast
@@ -87,6 +87,7 @@ Module {
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 66
 .  .  .  .  .  .  .  .  Line: 5

--- a/tests/functiondef_kwarg.py.uast
+++ b/tests/functiondef_kwarg.py.uast
@@ -113,6 +113,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 46
 .  .  .  .  .  .  .  .  Line: 2
@@ -272,6 +273,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 115
 .  .  .  .  .  .  .  .  Line: 5

--- a/tests/functiondef_simple.py.uast
+++ b/tests/functiondef_simple.py.uast
@@ -114,6 +114,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 36
 .  .  .  .  .  .  .  .  Line: 2
@@ -489,6 +490,7 @@ Module {
 .  .  .  .  }
 .  .  .  .  1: Pass {
 .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 136
 .  .  .  .  .  .  Line: 9

--- a/tests/functiondef_vararg.py.uast
+++ b/tests/functiondef_vararg.py.uast
@@ -113,6 +113,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 42
 .  .  .  .  .  .  .  .  Line: 2

--- a/tests/if.py.uast
+++ b/tests/if.py.uast
@@ -882,6 +882,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 186
 .  .  .  .  .  .  .  .  Line: 18

--- a/tests/line_comment.py.uast
+++ b/tests/line_comment.py.uast
@@ -16,6 +16,7 @@ Module {
 .  Children: {
 .  .  0: Pass {
 .  .  .  Roles: Noop,Statement
+.  .  .  TOKEN "pass"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 31
 .  .  .  .  Line: 3

--- a/tests/loop_if.py.uast
+++ b/tests/loop_if.py.uast
@@ -38,6 +38,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 24
 .  .  .  .  .  .  .  .  Line: 2

--- a/tests/pass.py.uast
+++ b/tests/pass.py.uast
@@ -16,6 +16,7 @@ Module {
 .  Children: {
 .  .  0: Pass {
 .  .  .  Roles: Noop,Statement
+.  .  .  TOKEN "pass"
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
 .  .  .  .  Line: 1
@@ -88,6 +89,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 28
 .  .  .  .  .  .  .  .  Line: 3
@@ -175,6 +177,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 54
 .  .  .  .  .  .  .  .  Line: 6

--- a/tests/test.py.uast
+++ b/tests/test.py.uast
@@ -38,6 +38,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
 .  .  .  .  .  .  .  Roles: Noop,Statement
+.  .  .  .  .  .  .  TOKEN "pass"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
 .  .  .  .  .  .  .  .  Line: 2


### PR DESCRIPTION
While debugging other stuff, I noticed that Pass doesn't have any key than can be used as Token.