### PR TITLE
Fix/issue 77

### DIFF
--- a/tests/other_statements.py.native
+++ b/tests/other_statements.py.native
@@ -94,7 +94,9 @@
                             "names": [
                                 {
                                     "ast_type": "Name",
-                                    "col_offset": 4,
+                                    "col_offset": 12,
+                                    "end_col_offset": 12,
+                                    "end_lineno": 5,
                                     "id": "a",
                                     "lineno": 5
                                 }
@@ -109,7 +111,9 @@
                             "names": [
                                 {
                                     "ast_type": "Name",
-                                    "col_offset": 4,
+                                    "col_offset": 14,
+                                    "end_col_offset": 14,
+                                    "end_lineno": 6,
                                     "id": "b",
                                     "lineno": 6
                                 }

--- a/tests/other_statements.py.uast
+++ b/tests/other_statements.py.uast
@@ -181,9 +181,14 @@ Module {
 .  .  .  .  .  .  .  .  .  Roles: SimpleIdentifier,Expression
 .  .  .  .  .  .  .  .  .  TOKEN "a"
 .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 30
+.  .  .  .  .  .  .  .  .  .  Offset: 38
 .  .  .  .  .  .  .  .  .  .  Line: 5
-.  .  .  .  .  .  .  .  .  .  Col: 4
+.  .  .  .  .  .  .  .  .  .  Col: 12
+.  .  .  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  .  .  EndPosition: {
+.  .  .  .  .  .  .  .  .  .  Offset: 38
+.  .  .  .  .  .  .  .  .  .  Line: 5
+.  .  .  .  .  .  .  .  .  .  Col: 12
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: names
@@ -209,9 +214,14 @@ Module {
 .  .  .  .  .  .  .  .  .  Roles: SimpleIdentifier,Expression
 .  .  .  .  .  .  .  .  .  TOKEN "b"
 .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 43
+.  .  .  .  .  .  .  .  .  .  Offset: 53
 .  .  .  .  .  .  .  .  .  .  Line: 6
-.  .  .  .  .  .  .  .  .  .  Col: 4
+.  .  .  .  .  .  .  .  .  .  Col: 14
+.  .  .  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  .  .  EndPosition: {
+.  .  .  .  .  .  .  .  .  .  Offset: 53
+.  .  .  .  .  .  .  .  .  .  Line: 6
+.  .  .  .  .  .  .  .  .  .  Col: 14
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: names


### PR DESCRIPTION
Fixes #77 

The generated `Name` nodes for `global`/`nonlocal` where not being visited and thus their positions not updated by the tokenizer.

Also refactor these two copypaste methods into a single one with two aliases.