### PR TITLE
Comment improvements

### DIFF
--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -198,11 +198,17 @@ var AnnotationRules = On(Any).Self(
 		On(pyast.Name).Roles(uast.Identifier, uast.Expression),
 		// Comments and non significative whitespace
 		On(pyast.SameLineNoops).Roles(uast.Comment),
-		On(pyast.PreviousNoops).Roles(uast.Whitespace).Children(
-			On(HasInternalRole("lines")).Roles(uast.Comment),
+		On(pyast.PreviousNoops).Roles(uast.Noop).Children(
+			On(HasInternalRole("lines")).Self(
+				On(HasProperty("noop_line", "\n")).Roles(uast.Noop, uast.Whitespace),
+				On(Not(HasProperty("noop_line", "\n"))).Roles(uast.Noop, uast.Comment),
+			),
 		),
-		On(pyast.RemainderNoops).Roles(uast.Whitespace).Children(
-			On(HasInternalRole("lines")).Roles(uast.Comment),
+		On(pyast.RemainderNoops).Roles(uast.Noop).Children(
+			On(HasInternalRole("lines")).Self(
+				On(HasProperty("noop_line", "\n")).Roles(uast.Noop, uast.Whitespace),
+				On(Not(HasProperty("noop_line", "\n"))).Roles(uast.Noop, uast.Comment),
+			),
 		),
 
 		// TODO: check what Constant nodes are generated in the python AST and improve this

--- a/fixtures/annotations.py.uast
+++ b/fixtures/annotations.py.uast
@@ -82,7 +82,6 @@ Module {
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
 .  .  .  .  simple: 1
-.  .  .  .  value: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: Name {
@@ -144,8 +143,6 @@ Module {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {

--- a/fixtures/aritmeticops.py.native
+++ b/fixtures/aritmeticops.py.native
@@ -221,7 +221,7 @@
                         "ast_type": "NoopLine",
                         "col_offset": 1,
                         "lineno": 8,
-                        "noop_line": "# 1@2 FIXME: matmul\n"
+                        "noop_line": " 1@2 FIXME: matmul\n"
                     }
                 ]
             }

--- a/fixtures/aritmeticops.py.uast
+++ b/fixtures/aritmeticops.py.uast
@@ -475,7 +475,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  7: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 30
 .  .  .  .  Line: 8
@@ -491,8 +491,8 @@ Module {
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# 1@2 FIXME: matmul
+.  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  TOKEN " 1@2 FIXME: matmul
 "
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 30

--- a/fixtures/assert_constant.py.uast
+++ b/fixtures/assert_constant.py.uast
@@ -20,7 +20,6 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  msg: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: BoolLiteral {
@@ -58,7 +57,6 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  msg: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: BoolLiteral {

--- a/fixtures/classdef.py.native
+++ b/fixtures/classdef.py.native
@@ -115,14 +115,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 5,
                                             "lineno": 5,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 5,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     },
                                     {
@@ -200,14 +193,7 @@
                                                 "end_col_offset": 1,
                                                 "end_lineno": 8,
                                                 "lineno": 8,
-                                                "lines": [
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
-                                                        "lineno": 8,
-                                                        "noop_line": "\n"
-                                                    }
-                                                ]
+                                                "lines": []
                                             }
                                         }
                                     }
@@ -246,14 +232,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 12,
                                             "lineno": 12,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 12,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     }
                                 ],
@@ -354,14 +333,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 16,
                                 "lineno": 16,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 16,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],

--- a/fixtures/classdef.py.uast
+++ b/fixtures/classdef.py.uast
@@ -41,16 +41,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 2
 .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -67,7 +62,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 21
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -206,16 +200,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 6
 .  .  .  .  .  .  .  .  Col: 14
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -232,12 +221,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 19
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 72
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 5
@@ -250,21 +238,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 72
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 5
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -283,7 +256,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 25
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -321,16 +293,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 9
 .  .  .  .  .  .  .  .  Col: 5
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -390,7 +357,7 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 114
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 8
@@ -403,21 +370,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 114
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 8
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -463,16 +415,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 13
 .  .  .  .  .  .  .  .  Col: 5
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -489,12 +436,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 14
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 165
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 12
@@ -507,21 +453,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 165
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 12
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -683,7 +614,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 220
 .  .  .  .  .  .  .  .  Line: 16
@@ -696,21 +627,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 220
-.  .  .  .  .  .  .  .  .  .  Line: 16
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }

--- a/fixtures/classdef_inheritance.py.native
+++ b/fixtures/classdef_inheritance.py.native
@@ -53,14 +53,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 3,
                                 "lineno": 3,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 3,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         },
                         {
@@ -97,14 +90,7 @@
                 "end_col_offset": 1,
                 "end_lineno": 6,
                 "lineno": 6,
-                "lines": [
-                    {
-                        "ast_type": "NoopLine",
-                        "col_offset": 1,
-                        "lineno": 6,
-                        "noop_line": "\n"
-                    }
-                ]
+                "lines": []
             }
         }
     }

--- a/fixtures/classdef_inheritance.py.uast
+++ b/fixtures/classdef_inheritance.py.uast
@@ -112,7 +112,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28
 .  .  .  .  .  .  .  .  .  .  Line: 3
@@ -125,21 +125,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 28
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 3
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -188,7 +173,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  2: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 66
 .  .  .  .  Line: 6
@@ -201,21 +186,6 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: noops_remainder
-.  .  .  }
-.  .  .  Children: {
-.  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 66
-.  .  .  .  .  .  Line: 6
-.  .  .  .  .  .  Col: 1
-.  .  .  .  .  }
-.  .  .  .  .  Properties: {
-.  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  }
-.  .  .  .  }
 .  .  .  }
 .  .  }
 .  }

--- a/fixtures/classdef_metaclass_py3.py.native
+++ b/fixtures/classdef_metaclass_py3.py.native
@@ -57,14 +57,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 3,
                                 "lineno": 3,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 3,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],

--- a/fixtures/classdef_metaclass_py3.py.uast
+++ b/fixtures/classdef_metaclass_py3.py.uast
@@ -119,7 +119,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 49
 .  .  .  .  .  .  .  .  .  .  Line: 3
@@ -132,21 +132,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 49
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 3
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/comments.py
+++ b/fixtures/comments.py
@@ -2,4 +2,7 @@
 # second comment above
 a = 1 # line trailing comment
 # file trailing comment
+
+
+
 # second file trailing comment

--- a/fixtures/comments.py.native
+++ b/fixtures/comments.py.native
@@ -30,13 +30,13 @@
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 1,
-                                        "noop_line": "# comment above\n"
+                                        "noop_line": " comment above\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 2,
-                                        "noop_line": "# second comment above\n"
+                                        "noop_line": " second comment above\n"
                                     }
                                 ]
                             },
@@ -46,7 +46,9 @@
                                 "end_col_offset": 29,
                                 "end_lineno": 3,
                                 "lineno": 3,
-                                "noop_line": "# line trailing comment"
+                                "noop_line": [
+                                    "# line trailing comment"
+                                ]
                             }
                         }
                     ],
@@ -64,20 +66,20 @@
                 "ast_type": "RemainderNoops",
                 "col_offset": 1,
                 "end_col_offset": 1,
-                "end_lineno": 5,
+                "end_lineno": 8,
                 "lineno": 4,
                 "lines": [
                     {
                         "ast_type": "NoopLine",
                         "col_offset": 1,
                         "lineno": 4,
-                        "noop_line": "# file trailing comment\n"
+                        "noop_line": " file trailing comment\n"
                     },
                     {
                         "ast_type": "NoopLine",
                         "col_offset": 1,
-                        "lineno": 5,
-                        "noop_line": "# second file trailing comment\n"
+                        "lineno": 8,
+                        "noop_line": " second file trailing comment\n"
                     }
                 ]
             }

--- a/fixtures/comments.py.uast
+++ b/fixtures/comments.py.uast
@@ -35,7 +35,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0
 .  .  .  .  .  .  .  .  Line: 1
@@ -51,8 +51,8 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# comment above
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " comment above
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 0
@@ -64,8 +64,8 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# second comment above
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " second comment above
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 16
@@ -80,7 +80,7 @@ Module {
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# line trailing comment"
+.  .  .  .  .  .  .  TOKEN "[# line trailing comment]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 44
 .  .  .  .  .  .  .  .  Line: 3
@@ -117,15 +117,15 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 69
 .  .  .  .  Line: 4
 .  .  .  .  Col: 1
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 93
-.  .  .  .  Line: 5
+.  .  .  .  Offset: 96
+.  .  .  .  Line: 8
 .  .  .  .  Col: 1
 .  .  .  }
 .  .  .  Properties: {
@@ -133,8 +133,8 @@ Module {
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# file trailing comment
+.  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  TOKEN " file trailing comment
 "
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 69
@@ -146,12 +146,12 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# second file trailing comment
+.  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  TOKEN " second file trailing comment
 "
 .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 93
-.  .  .  .  .  .  Line: 5
+.  .  .  .  .  .  Offset: 96
+.  .  .  .  .  .  Line: 8
 .  .  .  .  .  .  Col: 1
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {

--- a/fixtures/continue_break.py.native
+++ b/fixtures/continue_break.py.native
@@ -156,14 +156,7 @@
                 "end_col_offset": 1,
                 "end_lineno": 6,
                 "lineno": 6,
-                "lines": [
-                    {
-                        "ast_type": "NoopLine",
-                        "col_offset": 1,
-                        "lineno": 6,
-                        "noop_line": "\n"
-                    }
-                ]
+                "lines": []
             }
         }
     }

--- a/fixtures/continue_break.py.uast
+++ b/fixtures/continue_break.py.uast
@@ -322,7 +322,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 79
 .  .  .  .  Line: 6
@@ -335,21 +335,6 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: noops_remainder
-.  .  .  }
-.  .  .  Children: {
-.  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 79
-.  .  .  .  .  .  Line: 6
-.  .  .  .  .  .  Col: 1
-.  .  .  .  .  }
-.  .  .  .  .  Properties: {
-.  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  }
-.  .  .  .  }
 .  .  .  }
 .  .  }
 .  }

--- a/fixtures/empty.py.native
+++ b/fixtures/empty.py.native
@@ -1,12 +1,6 @@
 {
     "status": "ok",
-    "language": "python",
+    "language": "",
     "errors": [],
-    "ast": {
-        "PY3AST": {
-            "ast_type": "Module",
-            "col_offset": 1,
-            "lineno": 1
-        }
-    }
+    "ast": null
 }

--- a/fixtures/empty.py.uast
+++ b/fixtures/empty.py.uast
@@ -1,14 +1,5 @@
-Status:  error
-Language:  python
+Status:  ok
+Language:  
 Errors: 
- .  column out of bounds: 1 [1, 0]
 UAST: 
-Module {
-.  Roles: File,Module
-.  StartPosition: {
-.  .  Offset: 0
-.  .  Line: 1
-.  .  Col: 1
-.  }
-}
 

--- a/fixtures/except.py.uast
+++ b/fixtures/except.py.uast
@@ -85,9 +85,6 @@ Module {
 .  .  .  .  .  .  .  .  Line: 3
 .  .  .  .  .  .  .  .  Col: 9
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  cause: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Call {
 .  .  .  .  .  .  .  .  .  Roles: Function,Call,Expression
@@ -314,7 +311,6 @@ Module {
 .  .  .  .  }
 .  .  .  .  3: ExceptHandler {
 .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 107
 .  .  .  .  .  .  Line: 6
@@ -322,7 +318,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  type: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Expr {

--- a/fixtures/functioncalls.py.uast
+++ b/fixtures/functioncalls.py.uast
@@ -485,7 +485,6 @@ Module {
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: keyword {
 .  .  .  .  .  .  .  Roles: Function,Call,Argument,Name
-.  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: keywords
 .  .  .  .  .  .  .  }

--- a/fixtures/functiondef_annotated.py.uast
+++ b/fixtures/functiondef_annotated.py.uast
@@ -26,8 +26,6 @@ Module {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {

--- a/fixtures/functiondef_decorated.py.native
+++ b/fixtures/functiondef_decorated.py.native
@@ -67,14 +67,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 4,
                                 "lineno": 4,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 4,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             },
                             "value": null
                         }

--- a/fixtures/functiondef_decorated.py.uast
+++ b/fixtures/functiondef_decorated.py.uast
@@ -15,15 +15,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {
@@ -44,9 +41,6 @@ Module {
 .  .  .  .  .  .  .  .  Offset: 40
 .  .  .  .  .  .  .  .  Line: 3
 .  .  .  .  .  .  .  .  Col: 10
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }
@@ -88,15 +82,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {
@@ -118,12 +109,9 @@ Module {
 .  .  .  .  .  .  .  .  Line: 7
 .  .  .  .  .  .  .  .  Col: 10
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  value: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 42
 .  .  .  .  .  .  .  .  .  .  Line: 4
@@ -136,21 +124,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 42
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 4
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/functiondef_defaultparams.py.uast
+++ b/fixtures/functiondef_defaultparams.py.uast
@@ -20,15 +20,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -45,7 +42,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 17
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -63,7 +59,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 23
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -81,7 +76,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 29
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -99,7 +93,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 37
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -117,7 +110,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 54
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -168,9 +160,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  Line: 1
 .  .  .  .  .  .  .  .  .  .  Col: 59
 .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  value: <nil>
-.  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -215,14 +204,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Num {
@@ -256,7 +243,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 20
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: kwonlyargs
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -274,7 +260,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 13
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: vararg
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }

--- a/fixtures/functiondef_docstring.py.uast
+++ b/fixtures/functiondef_docstring.py.uast
@@ -20,15 +20,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {
@@ -92,9 +89,6 @@ Module {
 .  .  .  .  .  .  .  .  Offset: 80
 .  .  .  .  .  .  .  .  Line: 6
 .  .  .  .  .  .  .  .  Col: 10
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }

--- a/fixtures/functiondef_kwarg.py.native
+++ b/fixtures/functiondef_kwarg.py.native
@@ -78,14 +78,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 3,
                                     "lineno": 3,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 3,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {

--- a/fixtures/functiondef_kwarg.py.uast
+++ b/fixtures/functiondef_kwarg.py.uast
@@ -20,14 +20,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -44,7 +42,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 17
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -62,7 +59,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 23
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -80,7 +76,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: kwarg
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -125,7 +120,6 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
@@ -148,12 +142,11 @@ Module {
 .  .  .  .  .  .  .  .  Col: 23
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 51
 .  .  .  .  .  .  .  .  .  .  Line: 3
@@ -166,21 +159,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 51
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 3
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -199,7 +177,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 29
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -217,7 +194,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 56
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: kwarg
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -235,7 +211,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: vararg
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }

--- a/fixtures/functiondef_simple.py.native
+++ b/fixtures/functiondef_simple.py.native
@@ -95,14 +95,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 4,
                                     "lineno": 4,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 4,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -206,14 +199,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 7,
                                     "lineno": 7,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 7,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],

--- a/fixtures/functiondef_simple.py.uast
+++ b/fixtures/functiondef_simple.py.uast
@@ -20,15 +20,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -45,7 +42,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 17
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -63,7 +59,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 23
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -81,7 +76,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 29
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -160,15 +154,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -185,12 +176,11 @@ Module {
 .  .  .  .  .  .  .  .  Col: 14
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 57
 .  .  .  .  .  .  .  .  .  .  Line: 4
@@ -203,21 +193,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 57
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 4
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -236,7 +211,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 18
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -254,7 +228,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 22
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -382,15 +355,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -407,12 +377,11 @@ Module {
 .  .  .  .  .  .  .  .  Col: 24
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 104
 .  .  .  .  .  .  .  .  .  .  Line: 7
@@ -425,21 +394,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 104
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 7
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/functiondef_vararg.py.uast
+++ b/fixtures/functiondef_vararg.py.uast
@@ -20,14 +20,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -44,7 +42,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 17
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -62,7 +59,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 23
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -80,7 +76,6 @@ Module {
 .  .  .  .  .  .  .  .  Col: 35
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: vararg
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
@@ -118,9 +113,6 @@ Module {
 .  .  .  .  .  .  .  .  Offset: 56
 .  .  .  .  .  .  .  .  Line: 3
 .  .  .  .  .  .  .  .  Col: 10
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }

--- a/fixtures/if.py.native
+++ b/fixtures/if.py.native
@@ -114,14 +114,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 3,
                                 "lineno": 3,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 3,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         },
                         "keywords": [],
@@ -349,14 +342,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 6,
                                 "lineno": 6,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 6,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         },
                         "lineno": 7,
@@ -429,14 +415,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 16,
                                 "lineno": 16,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 16,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         },
                         "lineno": 17,

--- a/fixtures/if.py.uast
+++ b/fixtures/if.py.uast
@@ -223,7 +223,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 25
 .  .  .  .  .  .  .  .  .  .  Line: 3
@@ -236,21 +236,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 25
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 3
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -712,7 +697,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 61
 .  .  .  .  .  .  .  .  .  .  Line: 6
@@ -725,21 +710,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 61
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 6
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -888,7 +858,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 163
 .  .  .  .  .  .  .  .  .  .  Line: 16
@@ -901,21 +871,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 163
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 16
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/import.py.uast
+++ b/fixtures/import.py.uast
@@ -20,7 +20,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -41,7 +40,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -49,7 +47,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "os"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -84,7 +81,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "path"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -114,7 +110,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "join"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -122,7 +117,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "exists"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }

--- a/fixtures/issue119.py.uast
+++ b/fixtures/issue119.py.uast
@@ -20,15 +20,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {

--- a/fixtures/issue30.py.uast
+++ b/fixtures/issue30.py.uast
@@ -20,7 +20,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }

--- a/fixtures/issue58.py.uast
+++ b/fixtures/issue58.py.uast
@@ -110,7 +110,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: elts
-.  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }

--- a/fixtures/issue62.py.native
+++ b/fixtures/issue62.py.native
@@ -51,14 +51,7 @@
                         "end_col_offset": 1,
                         "end_lineno": 3,
                         "lineno": 3,
-                        "lines": [
-                            {
-                                "ast_type": "NoopLine",
-                                "col_offset": 1,
-                                "lineno": 3,
-                                "noop_line": "\n"
-                            }
-                        ]
+                        "lines": []
                     }
                 }
             ]

--- a/fixtures/issue62.py.uast
+++ b/fixtures/issue62.py.uast
@@ -34,7 +34,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "path"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -55,7 +54,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -90,7 +88,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 31
 .  .  .  .  .  .  Line: 3
@@ -103,21 +101,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  }
-.  .  .  .  .  Children: {
-.  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  Offset: 31
-.  .  .  .  .  .  .  .  Line: 3
-.  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  }
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }

--- a/fixtures/issue62_b.py.native
+++ b/fixtures/issue62_b.py.native
@@ -41,14 +41,7 @@
                         "end_col_offset": 1,
                         "end_lineno": 2,
                         "lineno": 2,
-                        "lines": [
-                            {
-                                "ast_type": "NoopLine",
-                                "col_offset": 1,
-                                "lineno": 2,
-                                "noop_line": "\n"
-                            }
-                        ]
+                        "lines": []
                     }
                 },
                 {
@@ -88,20 +81,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 6,
                                         "lineno": 5,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 5,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 6,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 }
                             ],
@@ -140,20 +120,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 10,
                                 "lineno": 9,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 9,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 10,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -213,14 +180,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 16,
                                             "lineno": 16,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 16,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     },
                                     {
@@ -466,14 +426,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 22,
                                             "lineno": 22,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 22,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     },
                                     {
@@ -933,20 +886,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 30,
                                 "lineno": 29,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 29,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 30,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         },
                         "lineno": 31,

--- a/fixtures/issue62_b.py.uast
+++ b/fixtures/issue62_b.py.uast
@@ -34,7 +34,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "Counter"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -64,12 +63,11 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "SIMPLE_IDENTIFIER"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 32
 .  .  .  .  .  .  Line: 2
@@ -82,21 +80,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  }
-.  .  .  .  .  Children: {
-.  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  Offset: 32
-.  .  .  .  .  .  .  .  Line: 2
-.  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  }
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }
@@ -125,7 +108,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "Repo2Base"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -181,7 +163,7 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 125
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 5
@@ -194,34 +176,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 125
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 5
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 126
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 6
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -290,7 +244,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 173
 .  .  .  .  .  .  .  .  .  .  Line: 9
@@ -303,34 +257,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 173
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 9
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 174
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 10
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -431,16 +357,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 17
 .  .  .  .  .  .  .  .  Col: 22
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -457,12 +378,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 27
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 319
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
@@ -475,21 +395,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 319
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -508,7 +413,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 33
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -526,7 +430,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 41
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -962,16 +865,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 23
 .  .  .  .  .  .  .  .  Col: 21
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -988,12 +886,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 26
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 525
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 22
@@ -1006,21 +903,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 525
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 22
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1039,7 +921,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 47
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1907,7 +1788,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 804
 .  .  .  .  .  .  .  .  .  .  Line: 29
@@ -1920,34 +1801,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 804
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 29
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 805
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 30
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/issue94.py.native
+++ b/fixtures/issue94.py.native
@@ -107,14 +107,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 7,
                                 "lineno": 7,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 7,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -176,14 +169,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 10,
                                         "lineno": 10,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 10,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 }
                             ],
@@ -214,14 +200,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 13,
                                             "lineno": 13,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 13,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     }
                                 ],
@@ -294,14 +273,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 16,
                                             "lineno": 16,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 16,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     }
                                 ],
@@ -452,14 +424,7 @@
                                                 "end_col_offset": 1,
                                                 "end_lineno": 21,
                                                 "lineno": 21,
-                                                "lines": [
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
-                                                        "lineno": 21,
-                                                        "noop_line": "\n"
-                                                    }
-                                                ]
+                                                "lines": []
                                             }
                                         }
                                     ],
@@ -512,14 +477,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 25,
                                         "lineno": 25,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 25,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 }
                             ],
@@ -692,14 +650,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 34,
                                 "lineno": 34,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 34,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],

--- a/fixtures/issue94.py.uast
+++ b/fixtures/issue94.py.uast
@@ -20,7 +20,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib1"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -41,7 +40,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib2.lib21"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -106,7 +104,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib41"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -136,7 +133,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib511"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -216,7 +212,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 142
 .  .  .  .  .  .  .  .  Line: 7
@@ -229,21 +225,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 142
-.  .  .  .  .  .  .  .  .  .  Line: 7
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }
@@ -263,7 +244,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  value: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }
@@ -312,7 +292,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  value: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }
@@ -367,7 +346,7 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 167
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 10
@@ -380,21 +359,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 167
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 10
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -414,7 +378,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -432,16 +395,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 14
 .  .  .  .  .  .  .  .  Col: 13
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -458,12 +416,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 18
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 196
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 13
@@ -476,21 +433,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 196
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 13
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -564,7 +506,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -586,16 +527,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 17
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -612,12 +548,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 239
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
@@ -630,21 +565,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 239
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -718,7 +638,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -784,7 +703,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -830,7 +748,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -852,16 +769,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 22
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -883,16 +795,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 23
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 13
 .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -916,7 +823,7 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 319
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 21
@@ -929,21 +836,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 319
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 21
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -1010,7 +902,7 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 360
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 25
@@ -1023,21 +915,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 360
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 25
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -1057,7 +934,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -1075,16 +951,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 28
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -1101,7 +972,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1136,7 +1006,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1158,16 +1027,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 30
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -1184,7 +1048,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1202,7 +1065,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 22
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1237,7 +1099,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1259,16 +1120,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 32
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -1300,7 +1156,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1351,7 +1206,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 469
 .  .  .  .  .  .  .  .  .  .  Line: 34
@@ -1364,21 +1219,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 469
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 34
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/issue96.py.native
+++ b/fixtures/issue96.py.native
@@ -107,14 +107,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 7,
                                 "lineno": 7,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 7,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -176,14 +169,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 10,
                                         "lineno": 10,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 10,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 }
                             ],
@@ -214,14 +200,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 13,
                                             "lineno": 13,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 13,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     }
                                 ],
@@ -294,14 +273,7 @@
                                             "end_col_offset": 1,
                                             "end_lineno": 16,
                                             "lineno": 16,
-                                            "lines": [
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
-                                                    "lineno": 16,
-                                                    "noop_line": "\n"
-                                                }
-                                            ]
+                                            "lines": []
                                         }
                                     }
                                 ],
@@ -452,14 +424,7 @@
                                                 "end_col_offset": 1,
                                                 "end_lineno": 21,
                                                 "lineno": 21,
-                                                "lines": [
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
-                                                        "lineno": 21,
-                                                        "noop_line": "\n"
-                                                    }
-                                                ]
+                                                "lines": []
                                             }
                                         }
                                     ],
@@ -512,14 +477,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 25,
                                         "lineno": 25,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 25,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 }
                             ],
@@ -692,14 +650,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 34,
                                 "lineno": 34,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 34,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],

--- a/fixtures/issue96.py.uast
+++ b/fixtures/issue96.py.uast
@@ -20,7 +20,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib1"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -41,7 +40,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib2.lib21"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -106,7 +104,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib41"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -136,7 +133,6 @@ Module {
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "lib511"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -216,7 +212,7 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 142
 .  .  .  .  .  .  .  .  Line: 7
@@ -229,21 +225,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 142
-.  .  .  .  .  .  .  .  .  .  Line: 7
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }
@@ -263,7 +244,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  value: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }
@@ -312,7 +292,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  value: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }
@@ -367,7 +346,7 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 167
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 10
@@ -380,21 +359,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 167
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 10
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -414,7 +378,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -432,16 +395,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 14
 .  .  .  .  .  .  .  .  Col: 13
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -458,12 +416,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 18
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 196
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 13
@@ -476,21 +433,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 196
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 13
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -564,7 +506,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -586,16 +527,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 17
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -612,12 +548,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 239
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
@@ -630,21 +565,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 239
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -718,7 +638,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -784,7 +703,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -830,7 +748,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -852,16 +769,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 22
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -883,16 +795,11 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 23
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 13
 .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -916,7 +823,7 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 319
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 21
@@ -929,21 +836,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 319
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 21
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -1010,7 +902,7 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 360
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 25
@@ -1023,21 +915,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 360
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 25
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -1057,7 +934,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -1075,16 +951,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 28
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -1101,7 +972,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1136,7 +1006,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1158,16 +1027,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 30
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: arg {
@@ -1184,7 +1048,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 16
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1202,7 +1065,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 22
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
@@ -1237,7 +1099,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1259,16 +1120,11 @@ Module {
 .  .  .  .  .  .  .  .  Line: 32
 .  .  .  .  .  .  .  .  Col: 11
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  returns: <nil>
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arguments {
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: FunctionDef.body {
@@ -1300,7 +1156,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -1351,7 +1206,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 469
 .  .  .  .  .  .  .  .  .  .  Line: 34
@@ -1364,21 +1219,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 469
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 34
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/issue_server101.py.native
+++ b/fixtures/issue_server101.py.native
@@ -27,49 +27,43 @@
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 1,
-                                    "noop_line": "# epydoc -- Introspection\n"
+                                    "noop_line": " epydoc -- Introspection\n"
                                 },
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 2,
-                                    "noop_line": "#\n"
+                                    "noop_line": "\n"
                                 },
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 3,
-                                    "noop_line": "# Copyright (C) 2005 Edward Loper\n"
+                                    "noop_line": " Copyright (C) 2005 Edward Loper\n"
                                 },
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 4,
-                                    "noop_line": "# Author: Edward Loper <edloper@loper.org>\n"
+                                    "noop_line": " Author: Edward Loper <edloper@loper.org>\n"
                                 },
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 5,
-                                    "noop_line": "# URL: <http://epydoc.sf.net>\n"
+                                    "noop_line": " URL: <http://epydoc.sf.net>\n"
                                 },
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 6,
-                                    "noop_line": "#\n"
+                                    "noop_line": "\n"
                                 },
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
                                     "lineno": 7,
-                                    "noop_line": "# $Id: docintrospecter.py 1678 2008-01-29 17:21:29Z edloper $\n"
-                                },
-                                {
-                                    "ast_type": "NoopLine",
-                                    "col_offset": 1,
-                                    "lineno": 8,
-                                    "noop_line": "\n"
+                                    "noop_line": " $Id: docintrospecter.py 1678 2008-01-29 17:21:29Z edloper $\n"
                                 }
                             ]
                         },
@@ -141,32 +135,20 @@
                             {
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
-                                "lineno": 23,
-                                "noop_line": "\n"
-                            },
-                            {
-                                "ast_type": "NoopLine",
-                                "col_offset": 1,
                                 "lineno": 24,
-                                "noop_line": "######################################################################\n"
+                                "noop_line": "#####################################################################\n"
                             },
                             {
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 25,
-                                "noop_line": "## Imports\n"
+                                "noop_line": "# Imports\n"
                             },
                             {
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 26,
-                                "noop_line": "######################################################################\n"
-                            },
-                            {
-                                "ast_type": "NoopLine",
-                                "col_offset": 1,
-                                "lineno": 27,
-                                "noop_line": "\n"
+                                "noop_line": "#####################################################################\n"
                             }
                         ]
                     }
@@ -195,7 +177,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 29,
-                                "noop_line": "# API documentation encoding:\n"
+                                "noop_line": " API documentation encoding:\n"
                             }
                         ]
                     }
@@ -226,7 +208,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 31,
-                                "noop_line": "# Type comparisons:\n"
+                                "noop_line": " Type comparisons:\n"
                             }
                         ]
                     }
@@ -257,7 +239,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 33,
-                                "noop_line": "# Error reporting:\n"
+                                "noop_line": " Error reporting:\n"
                             }
                         ]
                     }
@@ -286,7 +268,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 35,
-                                "noop_line": "# Helper functions:\n"
+                                "noop_line": " Helper functions:\n"
                             }
                         ]
                     }
@@ -313,7 +295,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 37,
-                                "noop_line": "# For extracting encoding for docstrings:\n"
+                                "noop_line": " For extracting encoding for docstrings:\n"
                             }
                         ]
                     }
@@ -340,7 +322,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 39,
-                                "noop_line": "# Builtin values\n"
+                                "noop_line": " Builtin values\n"
                             }
                         ]
                     }
@@ -369,7 +351,7 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 41,
-                                "noop_line": "# Backwards compatibility\n"
+                                "noop_line": " Backwards compatibility\n"
                             }
                         ]
                     }
@@ -397,32 +379,20 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 43,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 44,
-                                        "noop_line": "######################################################################\n"
+                                        "noop_line": "#####################################################################\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 45,
-                                        "noop_line": "## Caches\n"
+                                        "noop_line": "# Caches\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 46,
-                                        "noop_line": "######################################################################\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 47,
-                                        "noop_line": "\n"
+                                        "noop_line": "#####################################################################\n"
                                     }
                                 ]
                             }
@@ -468,14 +438,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 57,
                                 "lineno": 57,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 57,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -526,14 +489,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 61,
                                     "lineno": 61,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 61,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 },
                                 "s": "\n    Discard any cached C{APIDoc} values that have been computed for\n    introspected values.\n    "
                             }
@@ -631,32 +587,20 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 69,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 70,
-                                            "noop_line": "######################################################################\n"
+                                            "noop_line": "#####################################################################\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 71,
-                                            "noop_line": "## Introspection\n"
+                                            "noop_line": "# Introspection\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 72,
-                                            "noop_line": "######################################################################\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 73,
-                                            "noop_line": "\n"
+                                            "noop_line": "#####################################################################\n"
                                         }
                                     ]
                                 }
@@ -998,7 +942,7 @@
                                                                 "ast_type": "NoopLine",
                                                                 "col_offset": 1,
                                                                 "lineno": 108,
-                                                                "noop_line": "        # it's ok if value is None -- that's a value, after all.\n"
+                                                                "noop_line": " it's ok if value is None -- that's a value, after all.\n"
                                                             }
                                                         ]
                                                     }
@@ -1336,14 +1280,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 113,
                                         "lineno": 113,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 113,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 }
                             ],
@@ -1524,7 +1461,7 @@
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
                                                             "lineno": 119,
-                                                            "noop_line": "        # If the file is a script, then adjust its name.\n"
+                                                            "noop_line": " If the file is a script, then adjust its name.\n"
                                                         }
                                                     ]
                                                 }
@@ -1634,20 +1571,14 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 115,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 116,
-                                                "noop_line": "    # If we've already introspected this value, then simply return\n"
+                                                "noop_line": " If we've already introspected this value, then simply return\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 117,
-                                                "noop_line": "    # its ValueDoc from our cache.\n"
+                                                "noop_line": " its ValueDoc from our cache.\n"
                                             }
                                         ]
                                     }
@@ -1683,14 +1614,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 124,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 125,
-                                                "noop_line": "    # Create an initial value doc for this value & add it to the cache.\n"
+                                                "noop_line": " Create an initial value doc for this value & add it to the cache.\n"
                                             }
                                         ]
                                     }
@@ -1765,14 +1690,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 127,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 128,
-                                                    "noop_line": "    # Introspect the value.\n"
+                                                    "noop_line": " Introspect the value.\n"
                                                 }
                                             ]
                                         }
@@ -1999,14 +1918,8 @@
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
-                                                            "lineno": 132,
-                                                            "noop_line": "\n"
-                                                        },
-                                                        {
-                                                            "ast_type": "NoopLine",
-                                                            "col_offset": 1,
                                                             "lineno": 133,
-                                                            "noop_line": "    # Set canonical name, if it was given\n"
+                                                            "noop_line": " Set canonical name, if it was given\n"
                                                         }
                                                     ]
                                                 }
@@ -2178,14 +2091,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 136,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 137,
-                                                    "noop_line": "    # If the file is a script, then adjust its name.\n"
+                                                    "noop_line": " If the file is a script, then adjust its name.\n"
                                                 }
                                             ]
                                         }
@@ -2473,14 +2380,7 @@
                                                     "end_col_offset": 1,
                                                     "end_lineno": 140,
                                                     "lineno": 140,
-                                                    "lines": [
-                                                        {
-                                                            "ast_type": "NoopLine",
-                                                            "col_offset": 1,
-                                                            "lineno": 140,
-                                                            "noop_line": "\n"
-                                                        }
-                                                    ]
+                                                    "lines": []
                                                 }
                                             }
                                         },
@@ -2544,14 +2444,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 146,
                                     "lineno": 146,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 146,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         }
@@ -2580,14 +2473,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 148,
                                     "lineno": 148,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 148,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -3351,26 +3237,20 @@
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
-                                                            "lineno": 165,
-                                                            "noop_line": "\n"
-                                                        },
-                                                        {
-                                                            "ast_type": "NoopLine",
-                                                            "col_offset": 1,
                                                             "lineno": 166,
-                                                            "noop_line": "        # If it's a module, then do some preliminary introspection.\n"
+                                                            "noop_line": " If it's a module, then do some preliminary introspection.\n"
                                                         },
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
                                                             "lineno": 167,
-                                                            "noop_line": "        # Otherwise, check what the containing module is (used e.g.\n"
+                                                            "noop_line": " Otherwise, check what the containing module is (used e.g.\n"
                                                         },
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
                                                             "lineno": 168,
-                                                            "noop_line": "        # to decide what markup language should be used for docstrings)\n"
+                                                            "noop_line": " to decide what markup language should be used for docstrings)\n"
                                                         }
                                                     ]
                                                 }
@@ -3439,14 +3319,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 177,
                                     "lineno": 177,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 177,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         }
@@ -3481,44 +3354,32 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 179,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 180,
-                                        "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                        "noop_line": "////////////////////////////////////////////////////////////\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 181,
-                                        "noop_line": "# Module Introspection\n"
+                                        "noop_line": " Module Introspection\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 182,
-                                        "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 183,
-                                        "noop_line": "\n"
+                                        "noop_line": "////////////////////////////////////////////////////////////\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 184,
-                                        "noop_line": "#: A list of module variables that should not be included in a\n"
+                                        "noop_line": ": A list of module variables that should not be included in a\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 185,
-                                        "noop_line": "#: module's API documentation.\n"
+                                        "noop_line": ": module's API documentation.\n"
                                     }
                                 ]
                             }
@@ -3614,14 +3475,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 189,
                                     "lineno": 189,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 189,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -3844,14 +3698,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 196,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 197,
-                                                "noop_line": "    # Record the module's docformat\n"
+                                                "noop_line": " Record the module's docformat\n"
                                             }
                                         ]
                                     }
@@ -4171,14 +4019,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 200,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 201,
-                                                "noop_line": "    # Record the module's filename\n"
+                                                "noop_line": " Record the module's filename\n"
                                             }
                                         ]
                                     }
@@ -4220,32 +4062,26 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 209,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 210,
-                                                    "noop_line": "    # If this is just a preliminary introspection, then don't do\n"
+                                                    "noop_line": " If this is just a preliminary introspection, then don't do\n"
                                                 },
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
                                                     "lineno": 211,
-                                                    "noop_line": "    # anything else.  (Typically this is true if this module was\n"
+                                                    "noop_line": " anything else.  (Typically this is true if this module was\n"
                                                 },
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
                                                     "lineno": 212,
-                                                    "noop_line": "    # imported, but is not included in the set of modules we're\n"
+                                                    "noop_line": " imported, but is not included in the set of modules we're\n"
                                                 },
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
                                                     "lineno": 213,
-                                                    "noop_line": "    # documenting.)\n"
+                                                    "noop_line": " documenting.)\n"
                                                 }
                                             ]
                                         }
@@ -4389,14 +4225,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 216,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 217,
-                                                "noop_line": "    # Record the module's docstring\n"
+                                                "noop_line": " Record the module's docstring\n"
                                             }
                                         ]
                                     }
@@ -4669,20 +4499,14 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 220,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 221,
-                                                "noop_line": "    # If the module has a __path__, then it's (probably) a\n"
+                                                "noop_line": " If the module has a __path__, then it's (probably) a\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 222,
-                                                "noop_line": "    # package; so set is_package=True and record its __path__.\n"
+                                                "noop_line": " package; so set is_package=True and record its __path__.\n"
                                             }
                                         ]
                                     }
@@ -4716,14 +4540,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 230,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 231,
-                                                "noop_line": "    # Make sure we have a name for the package.\n"
+                                                "noop_line": " Make sure we have a name for the package.\n"
                                             }
                                         ]
                                     }
@@ -5245,14 +5063,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 236,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 237,
-                                                    "noop_line": "    # Record the module's parent package, if it has one.\n"
+                                                    "noop_line": " Record the module's parent package, if it has one.\n"
                                                 }
                                             ]
                                         }
@@ -5301,14 +5113,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 245,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 246,
-                                                    "noop_line": "    # Initialize the submodules property\n"
+                                                    "noop_line": " Initialize the submodules property\n"
                                                 }
                                             ]
                                         }
@@ -5449,14 +5255,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 248,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 249,
-                                                    "noop_line": "    # Add the module to its parent package's submodules list.\n"
+                                                    "noop_line": " Add the module to its parent package's submodules list.\n"
                                                 }
                                             ]
                                         }
@@ -5493,14 +5293,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 252,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 253,
-                                                "noop_line": "    # Look up the module's __all__ attribute (public names).\n"
+                                                "noop_line": " Look up the module's __all__ attribute (public names).\n"
                                             }
                                         ]
                                     }
@@ -5747,14 +5541,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 260,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 261,
-                                                    "noop_line": "    # Record the module's variables.\n"
+                                                    "noop_line": " Record the module's variables.\n"
                                                 }
                                             ]
                                         }
@@ -5895,20 +5683,14 @@
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
-                                                        "lineno": 266,
-                                                        "noop_line": "\n"
-                                                    },
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
                                                         "lineno": 267,
-                                                        "noop_line": "        # Create a VariableDoc for the child, and introspect its\n"
+                                                        "noop_line": " Create a VariableDoc for the child, and introspect its\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 268,
-                                                        "noop_line": "        # value if it's defined in this module.\n"
+                                                        "noop_line": " value if it's defined in this module.\n"
                                                     }
                                                 ]
                                             }
@@ -5970,7 +5752,7 @@
                                                                 "ast_type": "NoopLine",
                                                                 "col_offset": 1,
                                                                 "lineno": 274,
-                                                                "noop_line": "            # Local variable.\n"
+                                                                "noop_line": " Local variable.\n"
                                                             }
                                                         ]
                                                     }
@@ -6188,14 +5970,8 @@
                                                                     {
                                                                         "ast_type": "NoopLine",
                                                                         "col_offset": 1,
-                                                                        "lineno": 283,
-                                                                        "noop_line": "\n"
-                                                                    },
-                                                                    {
-                                                                        "ast_type": "NoopLine",
-                                                                        "col_offset": 1,
                                                                         "lineno": 284,
-                                                                        "noop_line": "            # Don't introspect stuff \"from __future__\"\n"
+                                                                        "noop_line": " Don't introspect stuff \"from __future__\"\n"
                                                                     }
                                                                 ]
                                                             }
@@ -6229,14 +6005,8 @@
                                                                     {
                                                                         "ast_type": "NoopLine",
                                                                         "col_offset": 1,
-                                                                        "lineno": 286,
-                                                                        "noop_line": "\n"
-                                                                    },
-                                                                    {
-                                                                        "ast_type": "NoopLine",
-                                                                        "col_offset": 1,
                                                                         "lineno": 287,
-                                                                        "noop_line": "            # Possibly imported variable.\n"
+                                                                        "noop_line": " Possibly imported variable.\n"
                                                                     }
                                                                 ]
                                                             }
@@ -6399,7 +6169,7 @@
                                                                         "ast_type": "NoopLine",
                                                                         "col_offset": 1,
                                                                         "lineno": 294,
-                                                                        "noop_line": "            # Imported variable.\n"
+                                                                        "noop_line": " Imported variable.\n"
                                                                     }
                                                                 ]
                                                             }
@@ -7005,20 +6775,14 @@
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
-                                                        "lineno": 301,
-                                                        "noop_line": "\n"
-                                                    },
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
                                                         "lineno": 302,
-                                                        "noop_line": "        # If the module's __all__ attribute is set, use it to set the\n"
+                                                        "noop_line": " If the module's __all__ attribute is set, use it to set the\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 303,
-                                                        "noop_line": "        # variables public/private status and imported status.\n"
+                                                        "noop_line": " variables public/private status and imported status.\n"
                                                     }
                                                 ]
                                             }
@@ -7075,14 +6839,7 @@
                                                         "end_col_offset": 1,
                                                         "end_lineno": 311,
                                                         "lineno": 311,
-                                                        "lines": [
-                                                            {
-                                                                "ast_type": "NoopLine",
-                                                                "col_offset": 1,
-                                                                "lineno": 311,
-                                                                "noop_line": "\n"
-                                                            }
-                                                        ]
+                                                        "lines": []
                                                     }
                                                 }
                                             }
@@ -7162,14 +6919,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 313,
                                     "lineno": 313,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 313,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         }
@@ -7204,44 +6954,32 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 315,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 316,
-                                        "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                        "noop_line": "////////////////////////////////////////////////////////////\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 317,
-                                        "noop_line": "# Class Introspection\n"
+                                        "noop_line": " Class Introspection\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 318,
-                                        "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 319,
-                                        "noop_line": "\n"
+                                        "noop_line": "////////////////////////////////////////////////////////////\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 320,
-                                        "noop_line": "#: A list of class variables that should not be included in a\n"
+                                        "noop_line": ": A list of class variables that should not be included in a\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 321,
-                                        "noop_line": "#: class's API documentation.\n"
+                                        "noop_line": ": class's API documentation.\n"
                                     }
                                 ]
                             }
@@ -7321,14 +7059,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 325,
                                     "lineno": 325,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 325,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -7453,14 +7184,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 332,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 333,
-                                                    "noop_line": "    # Record the class's docstring.\n"
+                                                    "noop_line": " Record the class's docstring.\n"
                                                 }
                                             ]
                                         }
@@ -7519,14 +7244,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 335,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 336,
-                                                "noop_line": "    # Record the class's __all__ attribute (public names).\n"
+                                                "noop_line": " Record the class's __all__ attribute (public names).\n"
                                             }
                                         ]
                                     }
@@ -7773,14 +7492,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 343,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 344,
-                                                    "noop_line": "    # Start a list of subclasses.\n"
+                                                    "noop_line": " Start a list of subclasses.\n"
                                                 }
                                             ]
                                         }
@@ -7818,80 +7531,74 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 346,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 347,
-                                                "noop_line": "    # Sometimes users will define a __metaclass__ that copies all\n"
+                                                "noop_line": " Sometimes users will define a __metaclass__ that copies all\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 348,
-                                                "noop_line": "    # class attributes from bases directly into the derived class's\n"
+                                                "noop_line": " class attributes from bases directly into the derived class's\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 349,
-                                                "noop_line": "    # __dict__ when the class is created.  (This saves the lookup time\n"
+                                                "noop_line": " __dict__ when the class is created.  (This saves the lookup time\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 350,
-                                                "noop_line": "    # needed to search the base tree for an attribute.)  But for the\n"
+                                                "noop_line": " needed to search the base tree for an attribute.)  But for the\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 351,
-                                                "noop_line": "    # docs, we only want to list these copied attributes in the\n"
+                                                "noop_line": " docs, we only want to list these copied attributes in the\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 352,
-                                                "noop_line": "    # parent.  So only add an attribute if it is not identical to an\n"
+                                                "noop_line": " parent.  So only add an attribute if it is not identical to an\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 353,
-                                                "noop_line": "    # attribute of a base class.  (Unfortunately, this can sometimes\n"
+                                                "noop_line": " attribute of a base class.  (Unfortunately, this can sometimes\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 354,
-                                                "noop_line": "    # cause an attribute to look like it was inherited, even though it\n"
+                                                "noop_line": " cause an attribute to look like it was inherited, even though it\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 355,
-                                                "noop_line": "    # wasn't, if it happens to have the exact same value as the\n"
+                                                "noop_line": " wasn't, if it happens to have the exact same value as the\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 356,
-                                                "noop_line": "    # corresponding base's attribute.)  An example of a case where\n"
+                                                "noop_line": " corresponding base's attribute.)  An example of a case where\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 357,
-                                                "noop_line": "    # this helps is PyQt -- subclasses of QWidget get about 300\n"
+                                                "noop_line": " this helps is PyQt -- subclasses of QWidget get about 300\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 358,
-                                                "noop_line": "    # methods injected into them.\n"
+                                                "noop_line": " methods injected into them.\n"
                                             }
                                         ]
                                     }
@@ -8335,14 +8042,7 @@
                                                             "end_col_offset": 1,
                                                             "end_lineno": 376,
                                                             "lineno": 376,
-                                                            "lines": [
-                                                                {
-                                                                    "ast_type": "NoopLine",
-                                                                    "col_offset": 1,
-                                                                    "lineno": 376,
-                                                                    "noop_line": "\n"
-                                                                }
-                                                            ]
+                                                            "lines": []
                                                         }
                                                     }
                                                 },
@@ -8560,20 +8260,14 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 360,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 361,
-                                                "noop_line": "    # Record the class's base classes; and add the class to its\n"
+                                                "noop_line": " Record the class's base classes; and add the class to its\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 362,
-                                                "noop_line": "    # base class's subclass lists.\n"
+                                                "noop_line": " base class's subclass lists.\n"
                                             }
                                         ]
                                     }
@@ -8676,20 +8370,14 @@
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
-                                                        "lineno": 381,
-                                                        "noop_line": "\n"
-                                                    },
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
                                                         "lineno": 382,
-                                                        "noop_line": "    # The module name is not defined if the class is being introspected\n"
+                                                        "noop_line": " The module name is not defined if the class is being introspected\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 383,
-                                                        "noop_line": "    # as another class base.\n"
+                                                        "noop_line": " as another class base.\n"
                                                     }
                                                 ]
                                             }
@@ -8791,14 +8479,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 386,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 387,
-                                                    "noop_line": "    # Record the class's local variables.\n"
+                                                    "noop_line": " Record the class's local variables.\n"
                                                 }
                                             ]
                                         }
@@ -9125,14 +8807,7 @@
                                                             "end_col_offset": 1,
                                                             "end_lineno": 395,
                                                             "lineno": 395,
-                                                            "lines": [
-                                                                {
-                                                                    "ast_type": "NoopLine",
-                                                                    "col_offset": 1,
-                                                                    "lineno": 395,
-                                                                    "noop_line": "\n"
-                                                                }
-                                                            ]
+                                                            "lines": []
                                                         }
                                                     }
                                                 },
@@ -9625,14 +9300,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 407,
                                     "lineno": 407,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 407,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         }
@@ -9665,32 +9333,20 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 409,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 410,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 411,
-                                            "noop_line": "# Routine Introspection\n"
+                                            "noop_line": " Routine Introspection\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 412,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 413,
-                                            "noop_line": "\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         }
                                     ]
                                 }
@@ -10101,14 +9757,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 418,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 419,
-                                                "noop_line": "    # Extract the underying function\n"
+                                                "noop_line": " Extract the underying function\n"
                                             }
                                         ]
                                     }
@@ -10150,14 +9800,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 428,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 429,
-                                                    "noop_line": "    # Record the function's docstring.\n"
+                                                    "noop_line": " Record the function's docstring.\n"
                                                 }
                                             ]
                                         }
@@ -10315,14 +9959,8 @@
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
-                                                            "lineno": 435,
-                                                            "noop_line": "\n"
-                                                        },
-                                                        {
-                                                            "ast_type": "NoopLine",
-                                                            "col_offset": 1,
                                                             "lineno": 436,
-                                                            "noop_line": "        # Add the arguments.\n"
+                                                            "noop_line": " Add the arguments.\n"
                                                         }
                                                     ]
                                                 }
@@ -10438,14 +10076,8 @@
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
-                                                            "lineno": 440,
-                                                            "noop_line": "\n"
-                                                        },
-                                                        {
-                                                            "ast_type": "NoopLine",
-                                                            "col_offset": 1,
                                                             "lineno": 441,
-                                                            "noop_line": "        # Set default values for positional arguments.\n"
+                                                            "noop_line": " Set default values for positional arguments.\n"
                                                         }
                                                     ]
                                                 }
@@ -11005,14 +10637,8 @@
                                                             {
                                                                 "ast_type": "NoopLine",
                                                                 "col_offset": 1,
-                                                                "lineno": 448,
-                                                                "noop_line": "\n"
-                                                            },
-                                                            {
-                                                                "ast_type": "NoopLine",
-                                                                "col_offset": 1,
                                                                 "lineno": 449,
-                                                                "noop_line": "        # If it's a bound method, then strip off the first argument.\n"
+                                                                "noop_line": " If it's a bound method, then strip off the first argument.\n"
                                                             }
                                                         ]
                                                     }
@@ -11165,14 +10791,8 @@
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
-                                                        "lineno": 453,
-                                                        "noop_line": "\n"
-                                                    },
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
                                                         "lineno": 454,
-                                                        "noop_line": "        # Set the routine's line number.\n"
+                                                        "noop_line": " Set the routine's line number.\n"
                                                     }
                                                 ]
                                             }
@@ -11220,32 +10840,26 @@
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
-                                                            "lineno": 457,
-                                                            "noop_line": "\n"
-                                                        },
-                                                        {
-                                                            "ast_type": "NoopLine",
-                                                            "col_offset": 1,
                                                             "lineno": 458,
-                                                            "noop_line": "        # [XX] I should probably use UNKNOWN here??\n"
+                                                            "noop_line": " [XX] I should probably use UNKNOWN here??\n"
                                                         },
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
                                                             "lineno": 459,
-                                                            "noop_line": "        # dvarrazzo: if '...' is to be changed, also check that\n"
+                                                            "noop_line": " dvarrazzo: if '...' is to be changed, also check that\n"
                                                         },
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
                                                             "lineno": 460,
-                                                            "noop_line": "        # `docstringparser.process_arg_field()` works correctly.\n"
+                                                            "noop_line": " `docstringparser.process_arg_field()` works correctly.\n"
                                                         },
                                                         {
                                                             "ast_type": "NoopLine",
                                                             "col_offset": 1,
                                                             "lineno": 461,
-                                                            "noop_line": "        # See SF bug #1556024.\n"
+                                                            "noop_line": " See SF bug #1556024.\n"
                                                         }
                                                     ]
                                                 }
@@ -11421,14 +11035,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 431,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 432,
-                                                "noop_line": "    # Record the function's signature.\n"
+                                                "noop_line": " Record the function's signature.\n"
                                             }
                                         ]
                                     }
@@ -11531,14 +11139,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 467,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 468,
-                                                "noop_line": "    # Change type, if appropriate.\n"
+                                                "noop_line": " Change type, if appropriate.\n"
                                             }
                                         ]
                                     }
@@ -11658,14 +11260,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 473,
                                     "lineno": 473,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 473,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         }
@@ -11698,32 +11293,20 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 475,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 476,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 477,
-                                            "noop_line": "# Property Introspection\n"
+                                            "noop_line": " Property Introspection\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 478,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 479,
-                                            "noop_line": "\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         }
                                     ]
                                 }
@@ -11850,14 +11433,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 484,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 485,
-                                                    "noop_line": "    # Record the property's docstring.\n"
+                                                    "noop_line": " Record the property's docstring.\n"
                                                 }
                                             ]
                                         }
@@ -12142,14 +11719,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 487,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 488,
-                                                "noop_line": "    # Record the property's access functions.\n"
+                                                "noop_line": " Record the property's access functions.\n"
                                             }
                                         ]
                                     }
@@ -12180,14 +11751,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 493,
                                     "lineno": 493,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 493,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         }
@@ -12220,32 +11784,20 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 495,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 496,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 497,
-                                            "noop_line": "# Generic Value Introspection\n"
+                                            "noop_line": " Generic Value Introspection\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 498,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 499,
-                                            "noop_line": "\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         }
                                     ]
                                 }
@@ -12386,32 +11938,20 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 504,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 505,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 506,
-                                            "noop_line": "# Helper functions\n"
+                                            "noop_line": " Helper functions\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 507,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 508,
-                                            "noop_line": "\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         }
                                     ]
                                 }
@@ -12527,14 +12067,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 520,
                                 "lineno": 520,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 520,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -12614,14 +12147,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 523,
                                     "lineno": 523,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 523,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -12714,14 +12240,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 529,
                                 "lineno": 529,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 529,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -12752,14 +12271,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 531,
                                     "lineno": 531,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 531,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -12808,7 +12320,7 @@
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 537,
-                                                "noop_line": "    # Guard from unexpected implementation changes of the __future__ module.\n"
+                                                "noop_line": " Guard from unexpected implementation changes of the __future__ module.\n"
                                             }
                                         ]
                                     }
@@ -13141,14 +12653,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 554,
                                     "lineno": 554,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 554,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -14033,7 +13538,7 @@
                                                                             "ast_type": "NoopLine",
                                                                             "col_offset": 1,
                                                                             "lineno": 587,
-                                                                            "noop_line": "        # Don't issue a warning for this special case.\n"
+                                                                            "noop_line": " Don't issue a warning for this special case.\n"
                                                                         }
                                                                     ]
                                                                 }
@@ -14409,14 +13914,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 595,
                                     "lineno": 595,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 595,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -14725,7 +14223,7 @@
                                                                         "ast_type": "NoopLine",
                                                                         "col_offset": 1,
                                                                         "lineno": 618,
-                                                                        "noop_line": "                # Note -- this return bypasses verify_name check:\n"
+                                                                        "noop_line": " Note -- this return bypasses verify_name check:\n"
                                                                     }
                                                                 ]
                                                             }
@@ -14798,19 +14296,19 @@
                                                                     "ast_type": "NoopLine",
                                                                     "col_offset": 1,
                                                                     "lineno": 612,
-                                                                    "noop_line": "            # If the module is shadowed by a variable in its parent\n"
+                                                                    "noop_line": " If the module is shadowed by a variable in its parent\n"
                                                                 },
                                                                 {
                                                                     "ast_type": "NoopLine",
                                                                     "col_offset": 1,
                                                                     "lineno": 613,
-                                                                    "noop_line": "            # package(s), then add a prime mark to the end, to\n"
+                                                                    "noop_line": " package(s), then add a prime mark to the end, to\n"
                                                                 },
                                                                 {
                                                                     "ast_type": "NoopLine",
                                                                     "col_offset": 1,
                                                                     "lineno": 614,
-                                                                    "noop_line": "            # differentiate it from the variable that shadows it.\n"
+                                                                    "noop_line": " differentiate it from the variable that shadows it.\n"
                                                                 }
                                                             ]
                                                         }
@@ -14997,7 +14495,7 @@
                                                                         "ast_type": "NoopLine",
                                                                         "col_offset": 1,
                                                                         "lineno": 621,
-                                                                        "noop_line": "            # Name is not a valid Python identifier -- treat as script.\n"
+                                                                        "noop_line": " Name is not a valid Python identifier -- treat as script.\n"
                                                                     }
                                                                 ]
                                                             }
@@ -16081,14 +15579,7 @@
                                                                     "end_col_offset": 1,
                                                                     "end_lineno": 632,
                                                                     "lineno": 632,
-                                                                    "lines": [
-                                                                        {
-                                                                            "ast_type": "NoopLine",
-                                                                            "col_offset": 1,
-                                                                            "lineno": 632,
-                                                                            "noop_line": "\n"
-                                                                        }
-                                                                    ]
+                                                                    "lines": []
                                                                 }
                                                             }
                                                         },
@@ -16225,7 +15716,9 @@
                                                                             "end_col_offset": 62,
                                                                             "end_lineno": 635,
                                                                             "lineno": 635,
-                                                                            "noop_line": "# class method."
+                                                                            "noop_line": [
+                                                                                "# class method."
+                                                                            ]
                                                                         }
                                                                     }
                                                                 }
@@ -16268,14 +15761,7 @@
                                                 "end_col_offset": 1,
                                                 "end_lineno": 625,
                                                 "lineno": 625,
-                                                "lines": [
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
-                                                        "lineno": 625,
-                                                        "noop_line": "\n"
-                                                    }
-                                                ]
+                                                "lines": []
                                             }
                                         },
                                         "keywords": [],
@@ -16326,14 +15812,8 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 607,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 608,
-                                                "noop_line": "    # Get the name via introspection.\n"
+                                                "noop_line": " Get the name via introspection.\n"
                                             }
                                         ]
                                     }
@@ -16387,14 +15867,7 @@
                                         "end_col_offset": 1,
                                         "end_lineno": 651,
                                         "lineno": 651,
-                                        "lines": [
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
-                                                "lineno": 651,
-                                                "noop_line": "\n"
-                                            }
-                                        ]
+                                        "lines": []
                                     }
                                 },
                                 "keywords": [],
@@ -16428,14 +15901,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 653,
                                     "lineno": 653,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 653,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -17034,14 +16500,8 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 671,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 672,
-                                            "noop_line": "# [xx] not used:\n"
+                                            "noop_line": " [xx] not used:\n"
                                         }
                                     ]
                                 }
@@ -17262,14 +16722,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 681,
                                     "lineno": 681,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 681,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -17874,7 +17327,9 @@
                                                                     "end_col_offset": 55,
                                                                     "end_lineno": 693,
                                                                     "lineno": 693,
-                                                                    "noop_line": "# class method."
+                                                                    "noop_line": [
+                                                                        "# class method."
+                                                                    ]
                                                                 }
                                                             }
                                                         },
@@ -17982,14 +17437,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 703,
                                     "lineno": 703,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 703,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -18462,32 +17910,26 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 718,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 719,
-                                            "noop_line": "    # This fallback shouldn't usually be needed.  But it is needed in\n"
+                                            "noop_line": " This fallback shouldn't usually be needed.  But it is needed in\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 720,
-                                            "noop_line": "    # a couple special cases (including using epydoc to document\n"
+                                            "noop_line": " a couple special cases (including using epydoc to document\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 721,
-                                            "noop_line": "    # itself).  In particular, if a module gets loaded twice, using\n"
+                                            "noop_line": " itself).  In particular, if a module gets loaded twice, using\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 722,
-                                            "noop_line": "    # two different names for the same file, then this helps.\n"
+                                            "noop_line": " two different names for the same file, then this helps.\n"
                                         }
                                     ]
                                 }
@@ -18540,32 +17982,20 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 729,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 730,
-                                        "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                        "noop_line": "////////////////////////////////////////////////////////////\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 731,
-                                        "noop_line": "# Introspection Dispatch Table\n"
+                                        "noop_line": " Introspection Dispatch Table\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 732,
-                                        "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 733,
-                                        "noop_line": "\n"
+                                        "noop_line": "////////////////////////////////////////////////////////////\n"
                                     }
                                 ]
                             }
@@ -18764,14 +18194,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 756,
                                     "lineno": 756,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 756,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -18936,14 +18359,8 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 763,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 764,
-                                            "noop_line": "# Register the standard introspecter functions.\n"
+                                            "noop_line": " Register the standard introspecter functions.\n"
                                         }
                                     ]
                                 }
@@ -19414,14 +18831,8 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 772,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 773,
-                                        "noop_line": "# Register getset_descriptor as a property\n"
+                                        "noop_line": " Register getset_descriptor as a property\n"
                                     }
                                 ]
                             }
@@ -19680,14 +19091,8 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 782,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 783,
-                                        "noop_line": "# Register member_descriptor as a property\n"
+                                        "noop_line": " Register member_descriptor as a property\n"
                                     }
                                 ]
                             }
@@ -19943,32 +19348,20 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 792,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 793,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 794,
-                                            "noop_line": "# Import support\n"
+                                            "noop_line": " Import support\n"
                                         },
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
                                             "lineno": 795,
-                                            "noop_line": "#////////////////////////////////////////////////////////////\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 796,
-                                            "noop_line": "\n"
+                                            "noop_line": "////////////////////////////////////////////////////////////\n"
                                         }
                                     ]
                                 }
@@ -20024,7 +19417,7 @@
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 798,
-                                                "noop_line": "    # Normalize the filename.\n"
+                                                "noop_line": " Normalize the filename.\n"
                                             }
                                         ]
                                     }
@@ -20137,26 +19530,20 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 800,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 801,
-                                                "noop_line": "    # Divide the filename into a base directory and a name.  (For\n"
+                                                "noop_line": " Divide the filename into a base directory and a name.  (For\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 802,
-                                                "noop_line": "    # packages, use the package's parent directory as the base, and\n"
+                                                "noop_line": " packages, use the package's parent directory as the base, and\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 803,
-                                                "noop_line": "    # the directory name as its name).\n"
+                                                "noop_line": " the directory name as its name).\n"
                                             }
                                         ]
                                     }
@@ -20732,44 +20119,38 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 809,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 810,
-                                                "noop_line": "    # If the context wasn't provided, then check if the file is in a\n"
+                                                "noop_line": " If the context wasn't provided, then check if the file is in a\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 811,
-                                                "noop_line": "    # package directory.  If so, then update basedir & name to contain\n"
+                                                "noop_line": " package directory.  If so, then update basedir & name to contain\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 812,
-                                                "noop_line": "    # the topmost package's directory and the fully qualified name for\n"
+                                                "noop_line": " the topmost package's directory and the fully qualified name for\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 813,
-                                                "noop_line": "    # this file.  (This update assume the default value of __path__\n"
+                                                "noop_line": " this file.  (This update assume the default value of __path__\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 814,
-                                                "noop_line": "    # for the parent packages; if the parent packages override their\n"
+                                                "noop_line": " for the parent packages; if the parent packages override their\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 815,
-                                                "noop_line": "    # __path__s, then this can cause us not to find the value.)\n"
+                                                "noop_line": " __path__s, then this can cause us not to find the value.)\n"
                                             }
                                         ]
                                     }
@@ -20809,7 +20190,7 @@
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 824,
-                                                        "noop_line": "        # Combine the name.\n"
+                                                        "noop_line": " Combine the name.\n"
                                                     }
                                                 ]
                                             }
@@ -21122,7 +20503,7 @@
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 826,
-                                                        "noop_line": "        # Find the directory of the base package.\n"
+                                                        "noop_line": " Find the directory of the base package.\n"
                                                     }
                                                 ]
                                             }
@@ -21173,20 +20554,14 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 820,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 821,
-                                                "noop_line": "    # If a parent package was specified, then find the directory of\n"
+                                                "noop_line": " If a parent package was specified, then find the directory of\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 822,
-                                                "noop_line": "    # the topmost package, and the fully qualified name for this file.\n"
+                                                "noop_line": " the topmost package, and the fully qualified name for this file.\n"
                                             }
                                         ]
                                     }
@@ -21222,26 +20597,20 @@
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
-                                                "lineno": 831,
-                                                "noop_line": "\n"
-                                            },
-                                            {
-                                                "ast_type": "NoopLine",
-                                                "col_offset": 1,
                                                 "lineno": 832,
-                                                "noop_line": "    # Import the module.  (basedir is the directory of the module's\n"
+                                                "noop_line": " Import the module.  (basedir is the directory of the module's\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 833,
-                                                "noop_line": "    # topmost package, or its own directory if it's not in a package;\n"
+                                                "noop_line": " topmost package, or its own directory if it's not in a package;\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 834,
-                                                "noop_line": "    # and name is the fully qualified dotted name for the module.)\n"
+                                                "noop_line": " and name is the fully qualified dotted name for the module.)\n"
                                             }
                                         ]
                                     }
@@ -21396,13 +20765,13 @@
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 838,
-                                                        "noop_line": "        # This will make sure that we get the module itself, even\n"
+                                                        "noop_line": " This will make sure that we get the module itself, even\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 839,
-                                                        "noop_line": "        # if it is shadowed by a variable.  (E.g., curses.wrapper):\n"
+                                                        "noop_line": " if it is shadowed by a variable.  (E.g., curses.wrapper):\n"
                                                     }
                                                 ]
                                             }
@@ -21523,7 +20892,7 @@
                                                                 "ast_type": "NoopLine",
                                                                 "col_offset": 1,
                                                                 "lineno": 844,
-                                                                "noop_line": "            # Use this as a fallback -- it *shouldn't* ever be needed.\n"
+                                                                "noop_line": " Use this as a fallback -- it *shouldn't* ever be needed.\n"
                                                             }
                                                         ]
                                                     }
@@ -21659,14 +21028,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 848,
                                     "lineno": 848,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 848,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -21790,14 +21152,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 852,
                                     "lineno": 852,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 852,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -21910,20 +21265,14 @@
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
-                                                        "lineno": 861,
-                                                        "noop_line": "\n"
-                                                    },
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
                                                         "lineno": 862,
-                                                        "noop_line": "    # Import the topmost module/package.  If we fail, then check if\n"
+                                                        "noop_line": " Import the topmost module/package.  If we fail, then check if\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 863,
-                                                        "noop_line": "    # the requested name refers to a builtin.\n"
+                                                        "noop_line": " the requested name refers to a builtin.\n"
                                                     }
                                                 ]
                                             }
@@ -22667,14 +22016,8 @@
                                         {
                                             "ast_type": "NoopLine",
                                             "col_offset": 1,
-                                            "lineno": 873,
-                                            "noop_line": "\n"
-                                        },
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
                                             "lineno": 874,
-                                            "noop_line": "    # Find the requested value in the module/package or its submodules.\n"
+                                            "noop_line": " Find the requested value in the module/package or its submodules.\n"
                                         }
                                     ]
                                 }
@@ -22721,14 +22064,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 881,
                                     "lineno": 881,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 881,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -23116,14 +22452,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 891,
                                     "lineno": 891,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 891,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             },
                             {
@@ -23190,19 +22519,19 @@
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 898,
-                                                "noop_line": "    # Note that we just do a shallow copy of sys.  In particular,\n"
+                                                "noop_line": " Note that we just do a shallow copy of sys.  In particular,\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 899,
-                                                "noop_line": "    # any changes made to sys.modules will be kept.  But we do\n"
+                                                "noop_line": " any changes made to sys.modules will be kept.  But we do\n"
                                             },
                                             {
                                                 "ast_type": "NoopLine",
                                                 "col_offset": 1,
                                                 "lineno": 900,
-                                                "noop_line": "    # explicitly store sys.path.\n"
+                                                "noop_line": " explicitly store sys.path.\n"
                                             }
                                         ]
                                     }
@@ -23394,32 +22723,26 @@
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
-                                                        "lineno": 904,
-                                                        "noop_line": "\n"
-                                                    },
-                                                    {
-                                                        "ast_type": "NoopLine",
-                                                        "col_offset": 1,
                                                         "lineno": 905,
-                                                        "noop_line": "    # Add the current directory to sys.path, in case they're trying to\n"
+                                                        "noop_line": " Add the current directory to sys.path, in case they're trying to\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 906,
-                                                        "noop_line": "    # import a module by name that resides in the current directory.\n"
+                                                        "noop_line": " import a module by name that resides in the current directory.\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 907,
-                                                        "noop_line": "    # But add it to the end -- otherwise, the explicit directory added\n"
+                                                        "noop_line": " But add it to the end -- otherwise, the explicit directory added\n"
                                                     },
                                                     {
                                                         "ast_type": "NoopLine",
                                                         "col_offset": 1,
                                                         "lineno": 908,
-                                                        "noop_line": "    # in get_value_from_filename might get overwritten\n"
+                                                        "noop_line": " in get_value_from_filename might get overwritten\n"
                                                     }
                                                 ]
                                             }
@@ -23463,20 +22786,14 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 910,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 911,
-                                                    "noop_line": "    # Suppress input and output.  (These get restored when we restore\n"
+                                                    "noop_line": " Suppress input and output.  (These get restored when we restore\n"
                                                 },
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
                                                     "lineno": 912,
-                                                    "noop_line": "    # sys to old_sys).\n"
+                                                    "noop_line": " sys to old_sys).\n"
                                                 }
                                             ]
                                         }
@@ -23630,14 +22947,8 @@
                                                 {
                                                     "ast_type": "NoopLine",
                                                     "col_offset": 1,
-                                                    "lineno": 915,
-                                                    "noop_line": "\n"
-                                                },
-                                                {
-                                                    "ast_type": "NoopLine",
-                                                    "col_offset": 1,
                                                     "lineno": 916,
-                                                    "noop_line": "    # Remove any command-line arguments\n"
+                                                    "noop_line": " Remove any command-line arguments\n"
                                                 }
                                             ]
                                         }
@@ -23767,7 +23078,7 @@
                                                                             "ast_type": "NoopLine",
                                                                             "col_offset": 1,
                                                                             "lineno": 924,
-                                                                            "noop_line": "                # For importing scripts:\n"
+                                                                            "noop_line": " For importing scripts:\n"
                                                                         }
                                                                     ]
                                                                 }
@@ -23808,14 +23119,7 @@
                                                         "end_col_offset": 1,
                                                         "end_lineno": 918,
                                                         "lineno": 918,
-                                                        "lines": [
-                                                            {
-                                                                "ast_type": "NoopLine",
-                                                                "col_offset": 1,
-                                                                "lineno": 918,
-                                                                "noop_line": "\n"
-                                                            }
-                                                        ]
+                                                        "lines": []
                                                     }
                                                 },
                                                 "lineno": 921,
@@ -24297,7 +23601,7 @@
                                                                 "ast_type": "NoopLine",
                                                                 "col_offset": 1,
                                                                 "lineno": 937,
-                                                                "noop_line": "        # Restore the important values that we saved.\n"
+                                                                "noop_line": " Restore the important values that we saved.\n"
                                                             }
                                                         ]
                                                     }
@@ -24515,14 +23819,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 943,
                                     "lineno": 943,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 943,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -25327,14 +24624,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 967,
                                     "lineno": 967,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 967,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 },
                                 "s": "\n    A \"file-like\" object that discards anything that is written and\n    always reports end-of-file when read.  C{_DevNull} is used by\n    L{_import()} to discard output when importing modules; and to\n    ensure that stdin appears closed.\n    "
                             }
@@ -26090,32 +25380,20 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 992,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 993,
-                                        "noop_line": "######################################################################\n"
+                                        "noop_line": "#####################################################################\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 994,
-                                        "noop_line": "## Zope InterfaceClass\n"
+                                        "noop_line": "# Zope InterfaceClass\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 995,
-                                        "noop_line": "######################################################################\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 996,
-                                        "noop_line": "\n"
+                                        "noop_line": "#####################################################################\n"
                                     }
                                 ]
                             }
@@ -26204,38 +25482,26 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 1002,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 1003,
-                                        "noop_line": "######################################################################\n"
+                                        "noop_line": "#####################################################################\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 1004,
-                                        "noop_line": "## Zope Extension classes\n"
+                                        "noop_line": "# Zope Extension classes\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 1005,
-                                        "noop_line": "######################################################################\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 1006,
-                                        "noop_line": "\n"
+                                        "noop_line": "#####################################################################\n"
                                     },
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 1007,
-                                        "noop_line": "    # Register type(ExtensionClass.ExtensionClass)\n"
+                                        "noop_line": " Register type(ExtensionClass.ExtensionClass)\n"
                                     }
                                 ]
                             }
@@ -26423,14 +25689,8 @@
                                     {
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
-                                        "lineno": 1014,
-                                        "noop_line": "\n"
-                                    },
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
                                         "lineno": 1015,
-                                        "noop_line": "    # Register ExtensionClass.*MethodType\n"
+                                        "noop_line": " Register ExtensionClass.*MethodType\n"
                                     }
                                 ]
                             }
@@ -26626,32 +25886,8 @@
                                 {
                                     "ast_type": "NoopLine",
                                     "col_offset": 1,
-                                    "lineno": 1023,
-                                    "noop_line": "\n"
-                                },
-                                {
-                                    "ast_type": "NoopLine",
-                                    "col_offset": 1,
-                                    "lineno": 1024,
-                                    "noop_line": "\n"
-                                },
-                                {
-                                    "ast_type": "NoopLine",
-                                    "col_offset": 1,
-                                    "lineno": 1025,
-                                    "noop_line": "\n"
-                                },
-                                {
-                                    "ast_type": "NoopLine",
-                                    "col_offset": 1,
-                                    "lineno": 1026,
-                                    "noop_line": "\n"
-                                },
-                                {
-                                    "ast_type": "NoopLine",
-                                    "col_offset": 1,
                                     "lineno": 1027,
-                                    "noop_line": "# [xx]\n"
+                                    "noop_line": " [xx]\n"
                                 }
                             ]
                         },
@@ -26661,7 +25897,9 @@
                             "end_col_offset": 69,
                             "end_lineno": 1028,
                             "lineno": 1028,
-                            "noop_line": "# hm..  otherwise the following gets treated as a docstring!  ouch!"
+                            "noop_line": [
+                                "# hm..  otherwise the following gets treated as a docstring!  ouch!"
+                            ]
                         }
                     }
                 },

--- a/fixtures/issue_server101.py.uast
+++ b/fixtures/issue_server101.py.uast
@@ -46,7 +46,7 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0
 .  .  .  .  .  .  .  .  Line: 1
@@ -62,8 +62,8 @@ special value types.
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# epydoc -- Introspection
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " epydoc -- Introspection
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 0
@@ -75,8 +75,8 @@ special value types.
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 26
@@ -88,8 +88,8 @@ special value types.
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Copyright (C) 2005 Edward Loper
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Copyright (C) 2005 Edward Loper
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28
@@ -101,8 +101,8 @@ special value types.
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Author: Edward Loper <edloper@loper.org>
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Author: Edward Loper <edloper@loper.org>
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 62
@@ -114,8 +114,8 @@ special value types.
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# URL: <http://epydoc.sf.net>
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " URL: <http://epydoc.sf.net>
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 105
@@ -127,8 +127,8 @@ special value types.
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  5: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 135
@@ -140,25 +140,12 @@ special value types.
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  6: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# $Id: docintrospecter.py 1678 2008-01-29 17:21:29Z edloper $
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " $Id: docintrospecter.py 1678 2008-01-29 17:21:29Z edloper $
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 137
 .  .  .  .  .  .  .  .  .  .  Line: 7
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  7: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 199
-.  .  .  .  .  .  .  .  .  .  Line: 8
 .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
@@ -234,7 +221,6 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "inspect"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -242,7 +228,6 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "re"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -250,7 +235,6 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "sys"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -258,7 +242,6 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "os.path"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
@@ -266,12 +249,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "imp"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  5: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 727
 .  .  .  .  .  .  Line: 23
@@ -287,21 +269,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  Offset: 727
-.  .  .  .  .  .  .  .  Line: 23
-.  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  }
-.  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 728
@@ -312,9 +281,9 @@ special value types.
 .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
-.  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "## Imports
+.  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN "# Imports
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 799
@@ -325,26 +294,13 @@ special value types.
 .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
-.  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 810
 .  .  .  .  .  .  .  .  Line: 26
-.  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  }
-.  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  Offset: 881
-.  .  .  .  .  .  .  .  Line: 27
 .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
@@ -379,12 +335,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "*"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 920
 .  .  .  .  .  .  Line: 29
@@ -400,8 +355,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# API documentation encoding:
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " API documentation encoding:
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 920
@@ -445,12 +400,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "*"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 978
 .  .  .  .  .  .  Line: 31
@@ -466,8 +420,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# Type comparisons:
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " Type comparisons:
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 978
@@ -511,12 +465,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "log"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 1018
 .  .  .  .  .  .  Line: 33
@@ -532,8 +485,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# Error reporting:
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " Error reporting:
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1018
@@ -572,12 +525,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "*"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 1060
 .  .  .  .  .  .  Line: 35
@@ -593,8 +545,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# Helper functions:
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " Helper functions:
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1060
@@ -624,12 +576,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "epydoc.docparser"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 1106
 .  .  .  .  .  .  Line: 37
@@ -645,8 +596,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# For extracting encoding for docstrings:
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " For extracting encoding for docstrings:
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1106
@@ -676,12 +627,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "__builtin__"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 1172
 .  .  .  .  .  .  Line: 39
@@ -697,8 +647,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# Builtin values
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " Builtin values
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1172
@@ -737,12 +687,11 @@ special value types.
 .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  TOKEN "*"
 .  .  .  .  .  Properties: {
-.  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 1208
 .  .  .  .  .  .  Line: 41
@@ -758,8 +707,8 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# Backwards compatibility
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " Backwards compatibility
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1208
@@ -804,7 +753,7 @@ special value types.
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1263
 .  .  .  .  .  .  .  .  Line: 43
@@ -820,21 +769,8 @@ special value types.
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 1263
-.  .  .  .  .  .  .  .  .  .  Line: 43
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 1264
@@ -845,9 +781,9 @@ special value types.
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "## Caches
+.  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "# Caches
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 1335
@@ -858,26 +794,13 @@ special value types.
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 1345
 .  .  .  .  .  .  .  .  .  .  Line: 46
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 1416
-.  .  .  .  .  .  .  .  .  .  Line: 47
 .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
@@ -968,7 +891,7 @@ in L{_introspected_values}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 1843
 .  .  .  .  .  .  .  .  Line: 57
@@ -981,21 +904,6 @@ in L{_introspected_values}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 1843
-.  .  .  .  .  .  .  .  .  .  Line: 57
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }
@@ -1065,8 +973,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {
@@ -1104,7 +1010,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 1964
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 61
@@ -1117,21 +1023,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 1964
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 61
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -1155,8 +1046,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -1218,8 +1107,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -1289,8 +1176,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -1312,7 +1197,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 2154
 .  .  .  .  .  .  .  .  .  .  Line: 69
@@ -1328,21 +1213,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 2154
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 69
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 2155
@@ -1353,9 +1225,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "## Introspection
+.  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Introspection
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 2226
@@ -1366,26 +1238,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 2243
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 72
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 2314
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 73
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
@@ -1709,8 +1568,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -1722,8 +1579,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -1864,8 +1719,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -1951,8 +1804,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -2073,7 +1924,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4155
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 108
@@ -2089,8 +1940,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # it's ok if value is None -- that's a value, after all.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " it's ok if value is None -- that's a value, after all.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4155
@@ -2126,10 +1977,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 111
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 13
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Call,Expression
@@ -2140,8 +1987,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -2818,7 +2663,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4371
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 113
@@ -2832,21 +2677,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
 .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4371
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 113
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
@@ -2859,8 +2689,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -3038,8 +2866,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -3051,8 +2877,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -3064,8 +2888,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -3186,7 +3008,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4537
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 119
@@ -3202,8 +3024,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # If the file is a script, then adjust its name.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If the file is a script, then adjust its name.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4537
@@ -3421,7 +3243,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4397
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 115
@@ -3437,21 +3259,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4397
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 115
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # If we've already introspected this value, then simply return
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If we've already introspected this value, then simply return
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4398
@@ -3462,9 +3271,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # its ValueDoc from our cache.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " its ValueDoc from our cache.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4465
@@ -3522,7 +3331,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4791
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 124
@@ -3538,21 +3347,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4791
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 124
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Create an initial value doc for this value & add it to the cache.
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Create an initial value doc for this value & add it to the cache.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4792
@@ -3576,8 +3372,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -3685,7 +3479,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4899
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 127
@@ -3701,21 +3495,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4899
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 127
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Introspect the value.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Introspect the value.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 4900
@@ -3787,8 +3568,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -3848,8 +3627,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -4012,8 +3789,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -4148,7 +3923,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5074
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 132
@@ -4164,21 +3939,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5074
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 132
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Set canonical name, if it was given
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Set canonical name, if it was given
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5075
@@ -4356,8 +4118,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -4369,8 +4129,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -4382,8 +4140,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -4504,7 +4260,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5230
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 136
@@ -4520,21 +4276,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5230
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 136
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # If the file is a script, then adjust its name.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If the file is a script, then adjust its name.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5231
@@ -4676,8 +4419,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -4757,8 +4498,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -4908,8 +4647,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -4932,8 +4669,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -5114,7 +4849,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5405
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 140
@@ -5127,21 +4862,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5405
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 140
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -5267,7 +4987,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5718
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 146
@@ -5280,21 +5000,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 5718
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 146
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -5326,8 +5031,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -5349,7 +5052,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 5738
 .  .  .  .  .  .  .  .  .  .  Line: 148
@@ -5362,21 +5065,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 5738
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 148
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -5457,8 +5145,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -5536,8 +5222,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -5666,8 +5350,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -5739,7 +5421,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 6236
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 161
@@ -5875,8 +5556,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6104,8 +5783,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6302,8 +5979,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -6315,8 +5990,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6414,8 +6087,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6573,8 +6244,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6713,8 +6382,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6790,8 +6457,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -6849,7 +6514,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 6472
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 165
@@ -6865,21 +6530,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 6472
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 165
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # If it's a module, then do some preliminary introspection.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If it's a module, then do some preliminary introspection.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 6481
@@ -6890,9 +6542,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Otherwise, check what the containing module is (used e.g.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Otherwise, check what the containing module is (used e.g.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 6549
@@ -6903,9 +6555,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # to decide what markup language should be used for docstrings)
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " to decide what markup language should be used for docstrings)
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 6617
@@ -7031,7 +6683,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7087
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 177
@@ -7044,21 +6696,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7087
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 177
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -7099,7 +6736,7 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 7119
 .  .  .  .  .  .  .  .  Line: 179
@@ -7115,21 +6752,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 7119
-.  .  .  .  .  .  .  .  .  .  Line: 179
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 7120
@@ -7140,9 +6764,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Module Introspection
+.  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Module Introspection
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 7182
@@ -7153,9 +6777,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 7205
@@ -7166,22 +6790,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 7267
-.  .  .  .  .  .  .  .  .  .  Line: 183
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  5: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#: A list of module variables that should not be included in a
+.  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN ": A list of module variables that should not be included in a
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 7268
@@ -7192,9 +6803,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  6: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#: module's API documentation.
+.  .  .  .  .  .  .  .  4: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN ": module's API documentation.
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 7331
@@ -7382,8 +6993,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -7405,7 +7014,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 7517
 .  .  .  .  .  .  .  .  .  .  Line: 189
@@ -7418,21 +7027,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 7517
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 189
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -7588,8 +7182,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -7727,8 +7319,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -7802,8 +7392,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -7860,7 +7448,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7741
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 196
@@ -7876,21 +7464,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7741
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 196
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the module's docformat
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the module's docformat
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7742
@@ -7995,8 +7570,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -8061,7 +7634,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8054
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 204
@@ -8085,10 +7657,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -8113,7 +7682,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8094
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 205
@@ -8121,7 +7689,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Pass {
@@ -8231,8 +7798,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -8297,7 +7862,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8242
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 208
@@ -8449,8 +8013,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -8507,7 +8069,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7880
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 200
@@ -8523,21 +8085,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7880
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 200
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the module's filename
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the module's filename
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 7915
@@ -8601,7 +8150,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8266
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 209
@@ -8617,21 +8166,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8266
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 209
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # If this is just a preliminary introspection, then don't do
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If this is just a preliminary introspection, then don't do
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8267
@@ -8642,9 +8178,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # anything else.  (Typically this is true if this module was
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " anything else.  (Typically this is true if this module was
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8332
@@ -8655,9 +8191,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # imported, but is not included in the set of modules we're
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " imported, but is not included in the set of modules we're
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8397
@@ -8668,9 +8204,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # documenting.)
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " documenting.)
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8461
@@ -8732,9 +8268,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8536
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 215
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 26
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  value: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -8834,8 +8367,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -8889,8 +8420,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -8947,7 +8476,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8538
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 216
@@ -8963,21 +8492,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8538
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 216
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the module's docstring
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the module's docstring
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8539
@@ -9159,8 +8675,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: elt
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -9271,7 +8785,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8936
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 226
@@ -9295,10 +8808,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -9323,7 +8833,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8976
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 227
@@ -9331,7 +8840,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Pass {
@@ -9440,8 +8948,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -9498,7 +9004,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8663
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 220
@@ -9514,21 +9020,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8663
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 220
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # If the module has a __path__, then it's (probably) a
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If the module has a __path__, then it's (probably) a
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8664
@@ -9539,9 +9032,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # package; so set is_package=True and record its __path__.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " package; so set is_package=True and record its __path__.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 8723
@@ -9587,7 +9080,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9037
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 230
@@ -9603,21 +9096,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9037
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 230
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Make sure we have a name for the package.
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Make sure we have a name for the package.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9038
@@ -9727,8 +9207,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -9898,8 +9376,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -9911,8 +9387,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -9975,8 +9449,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -10098,8 +9570,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -10111,8 +9581,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -10212,8 +9680,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -10371,8 +9837,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -10605,8 +10069,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -10646,7 +10108,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9283
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 236
@@ -10662,21 +10124,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9283
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 236
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the module's parent package, if it has one.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the module's parent package, if it has one.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9292
@@ -10754,7 +10203,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9612
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 245
@@ -10770,21 +10219,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9612
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 245
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Initialize the submodules property
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Initialize the submodules property
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9613
@@ -10852,8 +10288,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -11063,7 +10497,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9685
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 248
@@ -11079,21 +10513,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9685
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 248
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Add the module to its parent package's submodules list.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Add the module to its parent package's submodules list.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9686
@@ -11153,7 +10574,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9855
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 252
@@ -11169,21 +10590,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9855
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 252
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Look up the module's __all__ attribute (public names).
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Look up the module's __all__ attribute (public names).
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 9856
@@ -11284,8 +10692,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: ListComp {
@@ -11308,8 +10714,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: elt
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -11440,7 +10844,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10068
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 258
@@ -11464,10 +10867,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -11492,7 +10892,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10108
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 259
@@ -11500,7 +10899,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Pass {
@@ -11535,8 +10933,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -11641,7 +11037,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10121
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 260
@@ -11657,21 +11053,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10121
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 260
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the module's variables.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the module's variables.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10122
@@ -11862,8 +11245,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -11951,7 +11332,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10328
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 266
@@ -11967,21 +11348,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10328
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 266
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Create a VariableDoc for the child, and introspect its
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Create a VariableDoc for the child, and introspect its
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10329
@@ -11992,9 +11360,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # value if it's defined in this module.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " value if it's defined in this module.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10394
@@ -12018,8 +11386,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -12109,7 +11475,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10665
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 274
@@ -12125,8 +11491,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # Local variable.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Local variable.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 10665
@@ -12150,8 +11516,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -12283,8 +11647,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -12511,8 +11873,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -12552,7 +11912,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11220
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 283
@@ -12568,21 +11928,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11220
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 283
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # Don't introspect stuff "from __future__"
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Don't introspect stuff "from __future__"
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11221
@@ -12628,7 +11975,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11326
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 286
@@ -12644,21 +11991,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11326
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 286
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # Possibly imported variable.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Possibly imported variable.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11327
@@ -12682,8 +12016,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -12788,8 +12120,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -12956,7 +12286,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11708
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 294
@@ -12972,8 +12302,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # Imported variable.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Imported variable.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 11708
@@ -12997,8 +12327,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -13076,8 +12404,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -13969,8 +13295,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: operand
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -14236,7 +13560,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12102
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 301
@@ -14252,21 +13576,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12102
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 301
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # If the module's __all__ attribute is set, use it to set the
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If the module's __all__ attribute is set, use it to set the
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12103
@@ -14277,9 +13588,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # variables public/private status and imported status.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " variables public/private status and imported status.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12173
@@ -14393,7 +13704,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12544
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 311
@@ -14406,21 +13717,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12544
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 311
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -14460,8 +13756,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -14555,7 +13849,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12602
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 313
@@ -14568,21 +13862,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 12602
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 313
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -14623,7 +13902,7 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 12625
 .  .  .  .  .  .  .  .  Line: 315
@@ -14639,21 +13918,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 12625
-.  .  .  .  .  .  .  .  .  .  Line: 315
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12626
@@ -14664,9 +13930,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Class Introspection
+.  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Class Introspection
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12688
@@ -14677,9 +13943,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12710
@@ -14690,22 +13956,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 12772
-.  .  .  .  .  .  .  .  .  .  Line: 319
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  5: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#: A list of class variables that should not be included in a
+.  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN ": A list of class variables that should not be included in a
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12773
@@ -14716,9 +13969,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  6: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#: class's API documentation.
+.  .  .  .  .  .  .  .  4: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN ": class's API documentation.
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12835
@@ -14872,8 +14125,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -14895,7 +14146,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12984
 .  .  .  .  .  .  .  .  .  .  Line: 325
@@ -14908,21 +14159,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 12984
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 325
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -15043,8 +14279,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -15152,7 +14386,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13177
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 332
@@ -15168,21 +14402,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13177
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 332
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the class's docstring.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the class's docstring.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13178
@@ -15208,8 +14429,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -15279,7 +14498,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13259
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 335
@@ -15295,21 +14514,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13259
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 335
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the class's __all__ attribute (public names).
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the class's __all__ attribute (public names).
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13260
@@ -15410,8 +14616,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: ListComp {
@@ -15434,8 +14638,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: elt
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -15566,7 +14768,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13464
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 341
@@ -15590,10 +14791,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -15618,7 +14816,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13504
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 342
@@ -15626,7 +14823,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Pass {
@@ -15661,8 +14857,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -15767,7 +14961,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13517
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 343
@@ -15783,21 +14977,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13517
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 343
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Start a list of subclasses.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Start a list of subclasses.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13518
@@ -15855,7 +15036,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13582
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 346
@@ -15871,21 +15052,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13582
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 346
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Sometimes users will define a __metaclass__ that copies all
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Sometimes users will define a __metaclass__ that copies all
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13583
@@ -15896,9 +15064,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # class attributes from bases directly into the derived class's
+.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " class attributes from bases directly into the derived class's
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13649
@@ -15909,9 +15077,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # __dict__ when the class is created.  (This saves the lookup time
+.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " __dict__ when the class is created.  (This saves the lookup time
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13717
@@ -15922,9 +15090,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # needed to search the base tree for an attribute.)  But for the
+.  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " needed to search the base tree for an attribute.)  But for the
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13788
@@ -15935,9 +15103,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  5: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # docs, we only want to list these copied attributes in the
+.  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " docs, we only want to list these copied attributes in the
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13857
@@ -15948,9 +15116,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  6: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # parent.  So only add an attribute if it is not identical to an
+.  .  .  .  .  .  .  .  .  .  .  .  5: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " parent.  So only add an attribute if it is not identical to an
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13921
@@ -15961,9 +15129,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  7: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # attribute of a base class.  (Unfortunately, this can sometimes
+.  .  .  .  .  .  .  .  .  .  .  .  6: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " attribute of a base class.  (Unfortunately, this can sometimes
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 13990
@@ -15974,9 +15142,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  8: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # cause an attribute to look like it was inherited, even though it
+.  .  .  .  .  .  .  .  .  .  .  .  7: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " cause an attribute to look like it was inherited, even though it
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14059
@@ -15987,9 +15155,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  9: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # wasn't, if it happens to have the exact same value as the
+.  .  .  .  .  .  .  .  .  .  .  .  8: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " wasn't, if it happens to have the exact same value as the
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14130
@@ -16000,9 +15168,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  10: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # corresponding base's attribute.)  An example of a case where
+.  .  .  .  .  .  .  .  .  .  .  .  9: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " corresponding base's attribute.)  An example of a case where
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14194
@@ -16013,9 +15181,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  11: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # this helps is PyQt -- subclasses of QWidget get about 300
+.  .  .  .  .  .  .  .  .  .  .  .  10: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " this helps is PyQt -- subclasses of QWidget get about 300
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14261
@@ -16026,9 +15194,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  12: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # methods injected into them.
+.  .  .  .  .  .  .  .  .  .  .  .  11: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " methods injected into them.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14325
@@ -16122,8 +15290,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -16188,7 +15354,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14569
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 365
@@ -16196,7 +15361,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Assign {
@@ -16268,8 +15432,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -16311,8 +15473,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: right
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -16570,8 +15730,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -16631,8 +15789,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -16732,8 +15888,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -16873,8 +16027,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -16914,7 +16066,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15043
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 376
@@ -16927,21 +16079,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15043
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 376
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -17009,8 +16146,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -17104,8 +16239,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -17288,8 +16421,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -17346,7 +16477,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14382
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 360
@@ -17362,21 +16493,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14382
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 360
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the class's base classes; and add the class to its
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the class's base classes; and add the class to its
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14387
@@ -17387,9 +16505,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # base class's subclass lists.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " base class's subclass lists.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 14451
@@ -17588,7 +16706,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15217
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 381
@@ -17604,21 +16722,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15217
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 381
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # The module name is not defined if the class is being introspected
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " The module name is not defined if the class is being introspected
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15218
@@ -17629,9 +16734,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # as another class base.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " as another class base.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15290
@@ -17829,7 +16934,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15463
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 386
@@ -17845,21 +16950,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15463
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 386
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the class's local variables.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the class's local variables.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15472
@@ -17979,8 +17071,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: right
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -18374,8 +17464,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -18398,8 +17486,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -18501,8 +17587,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -18560,7 +17644,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15827
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 395
@@ -18573,21 +17657,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 15827
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 395
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -18739,8 +17808,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -18872,8 +17939,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -19330,8 +18395,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -19457,8 +18520,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -19551,7 +18612,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16485
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 407
@@ -19564,21 +18625,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16485
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 407
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -19610,8 +18656,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -19633,7 +18677,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 16507
 .  .  .  .  .  .  .  .  .  .  Line: 409
@@ -19649,21 +18693,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 16507
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 409
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16508
@@ -19674,9 +18705,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Routine Introspection
+.  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " Routine Introspection
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16570
@@ -19687,26 +18718,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16594
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 412
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 16656
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 413
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
@@ -19831,8 +18849,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -20039,8 +19055,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -20178,8 +19192,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -20308,8 +19320,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -20381,8 +19391,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -20454,8 +19462,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -20513,7 +19519,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16896
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 418
@@ -20529,21 +19535,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16896
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 418
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Extract the underying function
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Extract the underying function
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 16901
@@ -20607,7 +19600,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17205
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 428
@@ -20623,21 +19616,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17205
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 428
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the function's docstring.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the function's docstring.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17206
@@ -20663,8 +19643,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -20830,8 +19808,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -20939,7 +19915,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17439
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 435
@@ -20955,21 +19931,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17439
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 435
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Add the arguments.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Add the arguments.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17440
@@ -21183,7 +20146,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17574
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 440
@@ -21199,21 +20162,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17574
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 440
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Set default values for positional arguments.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Set default values for positional arguments.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17575
@@ -21289,8 +20239,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: right
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -21401,8 +20349,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -21459,8 +20405,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: right
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -21560,8 +20504,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -21799,8 +20741,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -21812,8 +20752,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -22048,8 +20986,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -22175,8 +21111,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -22268,8 +21202,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -22327,7 +21259,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17933
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 448
@@ -22343,21 +21275,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17933
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 448
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # If it's a bound method, then strip off the first argument.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If it's a bound method, then strip off the first argument.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17934
@@ -22603,8 +21522,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -22661,7 +21578,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18211
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 453
@@ -22677,21 +21594,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18211
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 453
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Set the routine's line number.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Set the routine's line number.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18212
@@ -22763,7 +21667,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18355
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 457
@@ -22779,21 +21683,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18355
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 457
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # [XX] I should probably use UNKNOWN here??
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " [XX] I should probably use UNKNOWN here??
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18356
@@ -22804,9 +21695,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # dvarrazzo: if '...' is to be changed, also check that
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " dvarrazzo: if '...' is to be changed, also check that
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18366
@@ -22817,9 +21708,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # `docstringparser.process_arg_field()` works correctly.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " `docstringparser.process_arg_field()` works correctly.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18418
@@ -22830,9 +21721,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # See SF bug #1556024.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " See SF bug #1556024.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18482
@@ -23105,8 +21996,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -23164,7 +22053,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17293
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 431
@@ -23180,21 +22069,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17293
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 431
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the function's signature.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the function's signature.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 17294
@@ -23250,8 +22126,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -23325,8 +22199,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -23384,7 +22256,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18728
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 467
@@ -23400,21 +22272,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18728
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 467
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Change type, if appropriate.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Change type, if appropriate.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18729
@@ -23470,8 +22329,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -23545,8 +22402,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -23640,7 +22495,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18948
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 473
@@ -23653,21 +22508,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18948
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 473
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -23699,8 +22539,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -23722,7 +22560,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 18980
 .  .  .  .  .  .  .  .  .  .  Line: 475
@@ -23738,21 +22576,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 18980
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 475
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 18981
@@ -23763,9 +22588,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Property Introspection
+.  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " Property Introspection
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19043
@@ -23776,26 +22601,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19068
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 478
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 19130
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 479
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
@@ -23920,8 +22732,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -24029,7 +22839,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19357
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 484
@@ -24045,21 +22855,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19357
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 484
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the property's docstring.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the property's docstring.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19358
@@ -24085,8 +22882,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -24231,8 +23026,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -24350,8 +23143,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -24469,8 +23260,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -24544,8 +23333,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -24602,7 +23389,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19467
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 487
@@ -24618,21 +23405,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19467
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 487
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Record the property's access functions.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Record the property's access functions.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19468
@@ -24684,7 +23458,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19697
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 493
@@ -24697,21 +23471,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19697
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 493
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -24743,8 +23502,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -24766,7 +23523,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 19722
 .  .  .  .  .  .  .  .  .  .  Line: 495
@@ -24782,21 +23539,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 19722
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 495
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19723
@@ -24807,9 +23551,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Generic Value Introspection
+.  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " Generic Value Introspection
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19785
@@ -24820,26 +23564,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19815
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 498
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 19877
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 499
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
@@ -24963,8 +23694,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -25086,8 +23815,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -25109,7 +23836,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 20062
 .  .  .  .  .  .  .  .  .  .  Line: 504
@@ -25125,21 +23852,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 20062
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 504
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 20063
@@ -25150,9 +23864,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Helper functions
+.  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " Helper functions
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 20125
@@ -25163,26 +23877,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 20144
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 507
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 20206
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 508
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
@@ -25259,8 +23960,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -25290,8 +23989,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -25388,7 +24085,7 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 20733
 .  .  .  .  .  .  .  .  Line: 520
@@ -25402,21 +24099,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: noops_previous
 .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 20733
-.  .  .  .  .  .  .  .  .  .  Line: 520
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }
 .  .  .  .  }
@@ -25429,8 +24111,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: List {
@@ -25556,8 +24236,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -25579,7 +24257,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 20833
 .  .  .  .  .  .  .  .  .  .  Line: 523
@@ -25592,21 +24270,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 20833
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 523
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -25665,8 +24328,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -25763,7 +24424,7 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 21038
 .  .  .  .  .  .  .  .  Line: 529
@@ -25776,21 +24437,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 21038
-.  .  .  .  .  .  .  .  .  .  Line: 529
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  }
@@ -25836,8 +24482,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -25859,7 +24503,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 21067
 .  .  .  .  .  .  .  .  .  .  Line: 531
@@ -25872,21 +24516,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 21067
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 531
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -25961,7 +24590,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 21208
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 537
@@ -25977,8 +24606,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Guard from unexpected implementation changes of the __future__ module.
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Guard from unexpected implementation changes of the __future__ module.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 21208
@@ -26047,7 +24676,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "__future__"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -26076,8 +24704,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -26310,8 +24936,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -26356,7 +24980,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 21631
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 549
@@ -26364,7 +24987,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Assign {
@@ -26436,8 +25058,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -26632,8 +25252,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -26655,7 +25273,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 21836
 .  .  .  .  .  .  .  .  .  .  Line: 554
@@ -26668,21 +25286,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 21836
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 554
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -26804,8 +25407,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -27051,8 +25652,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -27114,7 +25713,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 22267
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 568
@@ -27182,8 +25780,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -27367,8 +25963,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -27449,8 +26043,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -27551,8 +26143,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -27661,8 +26251,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -27725,7 +26313,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  4: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 22726
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 577
@@ -27749,10 +26336,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 47
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -27777,7 +26361,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  5: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 22774
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 578
@@ -28030,8 +26613,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -28085,8 +26666,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -28166,8 +26745,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -28288,8 +26865,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -28461,7 +27036,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 23191
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 587
@@ -28477,8 +27052,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Don't issue a warning for this special case.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Don't issue a warning for this special case.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 23191
@@ -28632,8 +27207,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -28687,8 +27260,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -28765,8 +27336,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -28983,8 +27552,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -29056,8 +27623,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -29215,8 +27780,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -29238,7 +27801,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 23487
 .  .  .  .  .  .  .  .  .  .  Line: 595
@@ -29251,21 +27814,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 23487
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 595
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -29439,8 +27987,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: operand
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -29568,8 +28114,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -29699,8 +28243,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -29818,8 +28360,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -29916,7 +28456,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24486
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 618
@@ -29932,8 +28472,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "                # Note -- this return bypasses verify_name check:
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Note -- this return bypasses verify_name check:
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24486
@@ -29999,8 +28539,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -30058,7 +28596,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24098
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 612
@@ -30074,8 +28612,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # If the module is shadowed by a variable in its parent
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If the module is shadowed by a variable in its parent
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24098
@@ -30087,8 +28625,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # package(s), then add a prime mark to the end, to
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " package(s), then add a prime mark to the end, to
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24166
@@ -30100,8 +28638,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # differentiate it from the variable that shadows it.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " differentiate it from the variable that shadows it.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24229
@@ -30136,7 +28674,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24614
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 620
@@ -30307,8 +28844,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -30320,8 +28855,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -30395,8 +28928,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -30453,7 +28984,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24651
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 621
@@ -30469,8 +29000,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # Name is not a valid Python identifier -- treat as script.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Name is not a valid Python identifier -- treat as script.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24651
@@ -30609,8 +29140,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -30743,8 +29272,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -31019,8 +29546,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -31244,8 +29769,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -31411,8 +29934,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -31636,8 +30157,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -31803,8 +30322,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -32008,8 +30525,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -32187,8 +30702,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -32274,8 +30787,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: operand
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -32389,8 +30900,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -32478,8 +30987,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: operand
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -32593,8 +31100,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -32652,7 +31157,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 25169
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 632
@@ -32665,21 +31170,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 25169
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 632
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -32891,8 +31381,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: operand
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -32968,7 +31456,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "# class method."
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "[# class method.]"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 25338
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 635
@@ -33008,8 +31496,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -33049,7 +31535,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24884
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 625
@@ -33062,21 +31548,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 24884
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 625
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -33096,8 +31567,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -33155,7 +31624,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 23940
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 607
@@ -33171,21 +31640,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 23940
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 607
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Get the name via introspection.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Get the name via introspection.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 23941
@@ -33227,8 +31683,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -33286,7 +31740,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 26102
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 651
@@ -33299,21 +31753,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 26102
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 651
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
@@ -33347,8 +31786,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -33370,7 +31807,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 26146
 .  .  .  .  .  .  .  .  .  .  Line: 653
@@ -33383,21 +31820,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 26146
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 653
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -33699,8 +32121,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -33764,8 +32184,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -33902,8 +32320,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -34217,8 +32633,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -34281,7 +32695,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 26663
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 666
@@ -34289,7 +32702,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Return {
@@ -34351,8 +32763,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -34607,8 +33017,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -34630,7 +33038,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 26775
 .  .  .  .  .  .  .  .  .  .  Line: 671
@@ -34646,21 +33054,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 26775
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 671
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# [xx] not used:
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " [xx] not used:
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 26776
@@ -34835,8 +33230,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -34890,8 +33283,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -34991,7 +33382,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  3: ExceptHandler {
 .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 26950
 .  .  .  .  .  .  .  .  .  .  Line: 679
@@ -34999,7 +33389,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Return {
@@ -35068,8 +33457,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -35091,7 +33478,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 26981
 .  .  .  .  .  .  .  .  .  .  Line: 681
@@ -35104,21 +33491,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 26981
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 681
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -35205,8 +33577,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -35315,8 +33685,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -35425,8 +33793,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -35555,8 +33921,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -35697,8 +34061,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -35890,8 +34252,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -35987,8 +34347,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -36062,8 +34420,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -36154,8 +34510,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -36378,7 +34732,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "# class method."
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "[# class method.]"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 27425
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 693
@@ -36426,8 +34780,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -36481,8 +34833,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -36570,8 +34920,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -36593,7 +34941,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 27765
 .  .  .  .  .  .  .  .  .  .  Line: 703
@@ -36606,21 +34954,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 27765
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 703
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -36750,8 +35083,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -36857,8 +35188,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -37022,7 +35351,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28145
 .  .  .  .  .  .  .  .  .  .  Line: 716
@@ -37046,10 +35374,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 35
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -37074,7 +35399,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  3: ExceptHandler {
 .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28181
 .  .  .  .  .  .  .  .  .  .  Line: 717
@@ -37082,7 +35406,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Pass {
@@ -37228,8 +35551,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -37296,8 +35617,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -37478,8 +35797,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -37561,7 +35878,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 28194
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 718
@@ -37577,21 +35894,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 28194
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 718
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # This fallback shouldn't usually be needed.  But it is needed in
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " This fallback shouldn't usually be needed.  But it is needed in
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 28195
@@ -37602,9 +35906,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # a couple special cases (including using epydoc to document
+.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " a couple special cases (including using epydoc to document
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 28265
@@ -37615,9 +35919,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # itself).  In particular, if a module gets loaded twice, using
+.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " itself).  In particular, if a module gets loaded twice, using
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 28330
@@ -37628,9 +35932,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # two different names for the same file, then this helps.
+.  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " two different names for the same file, then this helps.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 28398
@@ -37715,7 +36019,7 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 28692
 .  .  .  .  .  .  .  .  Line: 729
@@ -37731,21 +36035,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 28692
-.  .  .  .  .  .  .  .  .  .  Line: 729
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28693
@@ -37756,9 +36047,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Introspection Dispatch Table
+.  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Introspection Dispatch Table
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28755
@@ -37769,26 +36060,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 28786
 .  .  .  .  .  .  .  .  .  .  Line: 732
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 28848
-.  .  .  .  .  .  .  .  .  .  Line: 733
 .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
@@ -37834,8 +36112,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -37982,8 +36258,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Tuple {
@@ -38113,8 +36387,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -38184,8 +36456,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -38207,7 +36477,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 29965
 .  .  .  .  .  .  .  .  .  .  Line: 756
@@ -38220,21 +36490,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 29965
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 756
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -38332,8 +36587,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -38533,8 +36786,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -38556,7 +36807,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 30192
 .  .  .  .  .  .  .  .  .  .  Line: 763
@@ -38572,21 +36823,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 30192
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 763
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Register the standard introspecter functions.
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " Register the standard introspecter functions.
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 30193
@@ -38632,8 +36870,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -38719,8 +36955,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -38772,8 +37006,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -38859,8 +37091,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -38912,8 +37142,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -38998,8 +37226,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Attribute {
@@ -39126,8 +37352,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -39234,8 +37458,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Attribute {
@@ -39362,8 +37584,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -39476,12 +37696,11 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  .  .  TOKEN "array"
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 30685
 .  .  .  .  .  .  .  .  Line: 772
@@ -39497,21 +37716,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 30685
-.  .  .  .  .  .  .  .  .  .  Line: 772
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Register getset_descriptor as a property
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Register getset_descriptor as a property
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 30686
@@ -39564,8 +37770,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Attribute {
@@ -39706,8 +37910,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -39759,8 +37961,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -39845,8 +38045,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -39935,7 +38133,6 @@ pyid to C{bool}."
 .  .  .  .  }
 .  .  .  .  5: ExceptHandler {
 .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 30937
 .  .  .  .  .  .  Line: 780
@@ -39943,7 +38140,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  type: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
@@ -39993,12 +38189,11 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Roles: Import,Pathname,Identifier
 .  .  .  .  .  .  .  TOKEN "datetime"
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  asname: <nil>
 .  .  .  .  .  .  .  .  internalRole: names
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 30954
 .  .  .  .  .  .  .  .  Line: 782
@@ -40014,21 +38209,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 30954
-.  .  .  .  .  .  .  .  .  .  Line: 782
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# Register member_descriptor as a property
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Register member_descriptor as a property
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 30955
@@ -40081,8 +38263,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Attribute {
@@ -40223,8 +38403,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -40276,8 +38454,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -40362,8 +38538,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -40452,7 +38626,6 @@ pyid to C{bool}."
 .  .  .  .  }
 .  .  .  .  5: ExceptHandler {
 .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 31215
 .  .  .  .  .  .  Line: 790
@@ -40460,7 +38633,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  type: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
@@ -40505,8 +38677,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -40528,7 +38698,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 31232
 .  .  .  .  .  .  .  .  .  .  Line: 792
@@ -40544,21 +38714,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 31232
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 792
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31233
@@ -40569,9 +38726,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# Import support
+.  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " Import support
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31295
@@ -40582,26 +38739,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "#////////////////////////////////////////////////////////////
+.  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN "////////////////////////////////////////////////////////////
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31312
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 795
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 31374
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 796
 .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
@@ -40690,7 +38834,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31428
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 798
@@ -40706,8 +38850,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Normalize the filename.
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Normalize the filename.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31428
@@ -40731,8 +38875,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -40744,8 +38886,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -40915,7 +39055,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31517
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 800
@@ -40931,21 +39071,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31517
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 800
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Divide the filename into a base directory and a name.  (For
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Divide the filename into a base directory and a name.  (For
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31518
@@ -40956,9 +39083,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # packages, use the package's parent directory as the base, and
+.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " packages, use the package's parent directory as the base, and
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31584
@@ -40969,9 +39096,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # the directory name as its name).
+.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " the directory name as its name).
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31652
@@ -41032,8 +39159,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -41190,8 +39315,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -41240,8 +39363,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -41475,8 +39596,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -41663,8 +39782,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -41814,8 +39931,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -41933,8 +40048,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -42006,8 +40119,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -42107,7 +40218,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31893
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 809
@@ -42123,21 +40234,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31893
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 809
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # If the context wasn't provided, then check if the file is in a
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If the context wasn't provided, then check if the file is in a
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31894
@@ -42148,9 +40246,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # package directory.  If so, then update basedir & name to contain
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " package directory.  If so, then update basedir & name to contain
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 31963
@@ -42161,9 +40259,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # the topmost package's directory and the fully qualified name for
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " the topmost package's directory and the fully qualified name for
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32034
@@ -42174,9 +40272,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # this file.  (This update assume the default value of __path__
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " this file.  (This update assume the default value of __path__
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32105
@@ -42187,9 +40285,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  5: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # for the parent packages; if the parent packages override their
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " for the parent packages; if the parent packages override their
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32173
@@ -42200,9 +40298,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  6: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # __path__s, then this can cause us not to find the value.)
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  5: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " __path__s, then this can cause us not to find the value.)
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32242
@@ -42280,7 +40378,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32650
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 824
@@ -42296,8 +40394,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Combine the name.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Combine the name.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32650
@@ -42321,8 +40419,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -42495,8 +40591,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -42673,8 +40767,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -42914,7 +41006,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32734
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 826
@@ -42930,8 +41022,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Find the directory of the base package.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Find the directory of the base package.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32734
@@ -43019,7 +41111,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32470
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 820
@@ -43035,21 +41127,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32470
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 820
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # If a parent package was specified, then find the directory of
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " If a parent package was specified, then find the directory of
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32483
@@ -43060,9 +41139,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # the topmost package, and the fully qualified name for this file.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " the topmost package, and the fully qualified name for this file.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32551
@@ -43120,7 +41199,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32973
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 831
@@ -43136,21 +41215,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32973
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 831
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Import the module.  (basedir is the directory of the module's
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Import the module.  (basedir is the directory of the module's
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32974
@@ -43161,9 +41227,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # topmost package, or its own directory if it's not in a package;
+.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " topmost package, or its own directory if it's not in a package;
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33042
@@ -43174,9 +41240,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # and name is the fully qualified dotted name for the module.)
+.  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " and name is the fully qualified dotted name for the module.)
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33112
@@ -43207,9 +41273,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  lower: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: Attribute {
@@ -43282,8 +41345,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -43403,8 +41464,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -43416,8 +41475,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -43477,7 +41534,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33255
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 838
@@ -43493,8 +41550,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # This will make sure that we get the module itself, even
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " This will make sure that we get the module itself, even
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33255
@@ -43506,8 +41563,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # if it is shadowed by a variable.  (E.g., curses.wrapper):
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " if it is shadowed by a variable.  (E.g., curses.wrapper):
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33321
@@ -43590,8 +41647,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -43707,8 +41762,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -43748,7 +41801,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33509
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 844
@@ -43764,8 +41817,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "            # Use this as a fallback -- it *shouldn't* ever be needed.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Use this as a fallback -- it *shouldn't* ever be needed.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33509
@@ -43851,8 +41904,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: left
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -44005,8 +42056,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -44028,7 +42077,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 33670
 .  .  .  .  .  .  .  .  .  .  Line: 848
@@ -44041,21 +42090,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 33670
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 848
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -44103,8 +42137,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -44170,8 +42202,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -44257,8 +42287,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -44280,7 +42308,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 33786
 .  .  .  .  .  .  .  .  .  .  Line: 852
@@ -44293,21 +42321,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 33786
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 852
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -44430,8 +42443,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -44512,7 +42523,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34067
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 861
@@ -44528,21 +42539,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34067
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 861
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Import the topmost module/package.  If we fail, then check if
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Import the topmost module/package.  If we fail, then check if
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34068
@@ -44553,9 +42551,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # the requested name refers to a builtin.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " the requested name refers to a builtin.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34136
@@ -44579,8 +42577,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -44891,8 +42887,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -45008,8 +43002,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -45075,7 +43067,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34406
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 870
@@ -45083,7 +43074,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Raise {
@@ -45100,9 +43090,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 25
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -45149,11 +43137,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34452
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 872
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 17
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -45361,8 +43344,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -45399,8 +43380,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -45467,7 +43446,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34615
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 877
@@ -45551,8 +43529,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -45564,8 +43540,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -45584,8 +43558,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  lower: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -45761,8 +43733,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -45799,7 +43769,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -45929,8 +43898,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Num {
@@ -45959,8 +43926,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -46040,7 +44005,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34454
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 873
@@ -46056,21 +44021,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34454
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 873
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Find the requested value in the module/package or its submodules.
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Find the requested value in the module/package or its submodules.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34455
@@ -46146,8 +44098,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -46169,7 +44119,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 34751
 .  .  .  .  .  .  .  .  .  .  Line: 881
@@ -46182,21 +44132,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 34751
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 881
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -46339,8 +44274,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -46403,7 +44336,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 34890
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 886
@@ -46516,8 +44448,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: elts
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Subscript {
@@ -46536,8 +44466,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  lower: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -46676,9 +44604,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 17
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -46690,8 +44616,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -46767,8 +44691,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -46920,8 +44842,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -46943,7 +44863,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 35080
 .  .  .  .  .  .  .  .  .  .  Line: 891
@@ -46956,21 +44876,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 35080
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 891
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -47084,7 +44989,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35335
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 898
@@ -47100,8 +45005,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Note that we just do a shallow copy of sys.  In particular,
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Note that we just do a shallow copy of sys.  In particular,
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35335
@@ -47113,8 +45018,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # any changes made to sys.modules will be kept.  But we do
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " any changes made to sys.modules will be kept.  But we do
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35401
@@ -47126,8 +45031,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # explicitly store sys.path.
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " explicitly store sys.path.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35464
@@ -47151,8 +45056,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -47259,9 +45162,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: slice
-.  .  .  .  .  .  .  .  .  .  .  .  lower: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  step: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  upper: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: Attribute {
@@ -47341,8 +45241,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -47424,8 +45322,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -47499,7 +45395,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35609
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 904
@@ -47515,21 +45411,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35609
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 904
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Add the current directory to sys.path, in case they're trying to
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Add the current directory to sys.path, in case they're trying to
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35610
@@ -47540,9 +45423,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # import a module by name that resides in the current directory.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " import a module by name that resides in the current directory.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35681
@@ -47553,9 +45436,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # But add it to the end -- otherwise, the explicit directory added
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " But add it to the end -- otherwise, the explicit directory added
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35750
@@ -47566,9 +45449,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # in get_value_from_filename might get overwritten
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " in get_value_from_filename might get overwritten
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35821
@@ -47636,7 +45519,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35900
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 910
@@ -47652,21 +45535,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35900
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 910
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Suppress input and output.  (These get restored when we restore
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Suppress input and output.  (These get restored when we restore
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35901
@@ -47677,9 +45547,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # sys to old_sys).
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " sys to old_sys).
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 35971
@@ -47979,7 +45849,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36112
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 915
@@ -47995,21 +45865,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36112
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 915
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "    # Remove any command-line arguments
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Remove any command-line arguments
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36113
@@ -48124,8 +45981,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -48199,8 +46054,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -48276,7 +46129,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36297
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 924
@@ -48292,8 +46145,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "                # For importing scripts:
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " For importing scripts:
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36297
@@ -48371,7 +46224,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36183
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 918
@@ -48384,21 +46237,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36183
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 918
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -48421,7 +46259,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36401
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 926
@@ -48445,10 +46282,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 39
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: Name {
@@ -48473,7 +46307,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36441
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 927
@@ -48481,7 +46314,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  .  .  .  .  .  .  type: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Assign {
@@ -48572,8 +46404,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -49232,9 +47062,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 17
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  inst: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: body
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  tback: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Call {
@@ -49246,8 +47074,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -49314,8 +47140,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -49373,7 +47197,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36815
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 937
@@ -49389,8 +47213,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "        # Restore the important values that we saved.
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN " Restore the important values that we saved.
 "
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36815
@@ -49433,8 +47257,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -49537,8 +47359,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -49623,8 +47443,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -49803,8 +47621,6 @@ pyid to C{bool}."
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -49826,7 +47642,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 37054
 .  .  .  .  .  .  .  .  .  .  Line: 943
@@ -49839,21 +47655,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 37054
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 943
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -50162,8 +47963,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -50356,8 +48155,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: operand
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -50648,8 +48445,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: test
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Attribute {
@@ -50716,8 +48511,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Str {
@@ -50853,8 +48646,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: iter
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -50884,8 +48675,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -50968,7 +48757,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  3: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 37856
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 961
@@ -51017,7 +48805,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  4: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 37885
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 962
@@ -51066,7 +48853,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  5: ExceptHandler {
 .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 37916
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 963
@@ -51096,8 +48882,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: BinOp {
@@ -51267,8 +49051,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -51511,7 +49293,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 38068
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 967
@@ -51524,21 +49306,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 38068
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 967
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
@@ -51563,8 +49330,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -51875,8 +49640,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -51941,8 +49704,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52007,8 +49768,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52131,8 +49890,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52255,8 +50012,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52375,8 +50130,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52499,8 +50252,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52584,8 +50335,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52690,8 +50439,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52774,8 +50521,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -52928,8 +50673,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Name {
@@ -53003,7 +50746,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 38882
 .  .  .  .  .  .  .  .  Line: 992
@@ -53019,21 +50762,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 38882
-.  .  .  .  .  .  .  .  .  .  Line: 992
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 38887
@@ -53044,9 +50774,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "## Zope InterfaceClass
+.  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "# Zope InterfaceClass
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 38958
@@ -53057,26 +50787,13 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 38981
 .  .  .  .  .  .  .  .  .  .  Line: 995
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 39052
-.  .  .  .  .  .  .  .  .  .  Line: 996
 .  .  .  .  .  .  .  .  .  .  Col: 1
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
@@ -53107,8 +50824,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -53153,7 +50868,6 @@ pyid to C{bool}."
 .  .  .  .  }
 .  .  .  .  2: ExceptHandler {
 .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 39182
 .  .  .  .  .  .  Line: 1000
@@ -53161,7 +50875,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  type: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
@@ -53239,7 +50952,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 39199
 .  .  .  .  .  .  .  .  Line: 1002
@@ -53255,21 +50968,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 39199
-.  .  .  .  .  .  .  .  .  .  Line: 1002
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 39200
@@ -53280,9 +50980,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "## Zope Extension classes
+.  .  .  .  .  .  .  .  1: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "# Zope Extension classes
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 39271
@@ -53293,9 +50993,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "######################################################################
+.  .  .  .  .  .  .  .  2: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN "#####################################################################
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 39297
@@ -53306,22 +51006,9 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 39368
-.  .  .  .  .  .  .  .  .  .  Line: 1006
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  5: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "    # Register type(ExtensionClass.ExtensionClass)
+.  .  .  .  .  .  .  .  3: NoopLine {
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Register type(ExtensionClass.ExtensionClass)
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 39369
@@ -53374,8 +51061,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -53439,8 +51124,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -53492,8 +51175,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -53578,8 +51259,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -53683,7 +51362,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 39657
 .  .  .  .  .  .  .  .  Line: 1014
@@ -53699,21 +51378,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 39657
-.  .  .  .  .  .  .  .  .  .  Line: 1014
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "    # Register ExtensionClass.*MethodType
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " Register ExtensionClass.*MethodType
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 39658
@@ -53793,8 +51459,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -53846,8 +51510,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: Name {
@@ -53964,8 +51626,6 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  .  .  kwargs: <nil>
-.  .  .  .  .  .  .  .  starargs: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: Name {
@@ -54028,7 +51688,6 @@ pyid to C{bool}."
 .  .  .  .  }
 .  .  .  .  8: ExceptHandler {
 .  .  .  .  .  Roles: Try,Catch,Statement
-.  .  .  .  .  TOKEN "<nil>"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 39999
 .  .  .  .  .  .  Line: 1021
@@ -54036,7 +51695,6 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: handlers
-.  .  .  .  .  .  type: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Pass {
@@ -54089,7 +51747,7 @@ pyid to C{bool}."
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 40016
 .  .  .  .  .  .  .  .  Line: 1023
@@ -54105,60 +51763,8 @@ pyid to C{bool}."
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 40016
-.  .  .  .  .  .  .  .  .  .  Line: 1023
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 40042
-.  .  .  .  .  .  .  .  .  .  Line: 1024
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  2: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 40043
-.  .  .  .  .  .  .  .  .  .  Line: 1025
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  3: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  Offset: 40044
-.  .  .  .  .  .  .  .  .  .  Line: 1026
-.  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  4: NoopLine {
-.  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# [xx]
+.  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  TOKEN " [xx]
 "
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 40049
@@ -54173,7 +51779,7 @@ pyid to C{bool}."
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# hm..  otherwise the following gets treated as a docstring!  ouch!"
+.  .  .  .  .  .  .  TOKEN "[# hm..  otherwise the following gets treated as a docstring!  ouch!]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 40057
 .  .  .  .  .  .  .  .  Line: 1028

--- a/fixtures/lambda.py.uast
+++ b/fixtures/lambda.py.uast
@@ -36,8 +36,6 @@ Module {
 .  .  .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: arg {
@@ -54,7 +52,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  Col: 8
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }

--- a/fixtures/line_comment.py.native
+++ b/fixtures/line_comment.py.native
@@ -23,13 +23,13 @@
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 1,
-                                "noop_line": "# thse are\n"
+                                "noop_line": " thse are\n"
                             },
                             {
                                 "ast_type": "NoopLine",
                                 "col_offset": 1,
                                 "lineno": 2,
-                                "noop_line": "# previous comments\n"
+                                "noop_line": " previous comments\n"
                             }
                         ]
                     },
@@ -39,7 +39,9 @@
                         "end_col_offset": 23,
                         "end_lineno": 3,
                         "lineno": 3,
-                        "noop_line": "# sameline comment"
+                        "noop_line": [
+                            "# sameline comment"
+                        ]
                     }
                 }
             ],
@@ -53,20 +55,14 @@
                     {
                         "ast_type": "NoopLine",
                         "col_offset": 1,
-                        "lineno": 4,
-                        "noop_line": "\n"
-                    },
-                    {
-                        "ast_type": "NoopLine",
-                        "col_offset": 1,
                         "lineno": 5,
-                        "noop_line": "# remainder comment and newline\n"
+                        "noop_line": " remainder comment and newline\n"
                     },
                     {
                         "ast_type": "NoopLine",
                         "col_offset": 1,
                         "lineno": 6,
-                        "noop_line": "# last remainder comment line\n"
+                        "noop_line": " last remainder comment line\n"
                     }
                 ]
             }

--- a/fixtures/line_comment.py.uast
+++ b/fixtures/line_comment.py.uast
@@ -23,7 +23,7 @@ Module {
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  Roles: Noop
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 0
 .  .  .  .  .  .  Line: 1
@@ -39,8 +39,8 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# thse are
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " thse are
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 0
@@ -52,8 +52,8 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: NoopLine {
-.  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# previous comments
+.  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  TOKEN " previous comments
 "
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 11
@@ -68,7 +68,7 @@ Module {
 .  .  .  .  }
 .  .  .  .  1: SameLineNoops {
 .  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# sameline comment"
+.  .  .  .  .  TOKEN "[# sameline comment]"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 35
 .  .  .  .  .  .  Line: 3
@@ -86,7 +86,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 55
 .  .  .  .  Line: 4
@@ -102,21 +102,8 @@ Module {
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 55
-.  .  .  .  .  .  Line: 4
-.  .  .  .  .  .  Col: 1
-.  .  .  .  .  }
-.  .  .  .  .  Properties: {
-.  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  }
-.  .  .  .  }
-.  .  .  .  1: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# remainder comment and newline
+.  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  TOKEN " remainder comment and newline
 "
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 56
@@ -127,9 +114,9 @@ Module {
 .  .  .  .  .  .  internalRole: lines
 .  .  .  .  .  }
 .  .  .  .  }
-.  .  .  .  2: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# last remainder comment line
+.  .  .  .  1: NoopLine {
+.  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  TOKEN " last remainder comment line
 "
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 88

--- a/fixtures/literals_assign.py.native
+++ b/fixtures/literals_assign.py.native
@@ -25,7 +25,9 @@
                                 "end_col_offset": 11,
                                 "end_lineno": 1,
                                 "lineno": 1,
-                                "noop_line": "# int"
+                                "noop_line": [
+                                    "# int"
+                                ]
                             }
                         }
                     ],
@@ -57,7 +59,9 @@
                                 "end_col_offset": 16,
                                 "end_lineno": 2,
                                 "lineno": 2,
-                                "noop_line": "# float"
+                                "noop_line": [
+                                    "# float"
+                                ]
                             }
                         }
                     ],
@@ -89,7 +93,9 @@
                                 "end_col_offset": 25,
                                 "end_lineno": 3,
                                 "lineno": 3,
-                                "noop_line": "# string"
+                                "noop_line": [
+                                    "# string"
+                                ]
                             }
                         }
                     ],
@@ -121,7 +127,9 @@
                                 "end_col_offset": 15,
                                 "end_lineno": 4,
                                 "lineno": 4,
-                                "noop_line": "# None"
+                                "noop_line": [
+                                    "# None"
+                                ]
                             }
                         }
                     ],
@@ -154,7 +162,9 @@
                                 "end_col_offset": 28,
                                 "end_lineno": 5,
                                 "lineno": 5,
-                                "noop_line": "# list literal"
+                                "noop_line": [
+                                    "# list literal"
+                                ]
                             }
                         }
                     ],
@@ -210,7 +220,9 @@
                                 "end_col_offset": 29,
                                 "end_lineno": 6,
                                 "lineno": 6,
-                                "noop_line": "# tuple literal"
+                                "noop_line": [
+                                    "# tuple literal"
+                                ]
                             }
                         }
                     ],
@@ -266,7 +278,9 @@
                                 "end_col_offset": 27,
                                 "end_lineno": 7,
                                 "lineno": 7,
-                                "noop_line": "# set literal"
+                                "noop_line": [
+                                    "# set literal"
+                                ]
                             }
                         }
                     ],
@@ -321,7 +335,9 @@
                                 "end_col_offset": 35,
                                 "end_lineno": 8,
                                 "lineno": 8,
-                                "noop_line": "# dict literal"
+                                "noop_line": [
+                                    "# dict literal"
+                                ]
                             }
                         }
                     ],
@@ -386,7 +402,9 @@
                                 "end_col_offset": 42,
                                 "end_lineno": 9,
                                 "lineno": 9,
-                                "noop_line": "# expression assignment"
+                                "noop_line": [
+                                    "# expression assignment"
+                                ]
                             }
                         }
                     ],

--- a/fixtures/literals_assign.py.uast
+++ b/fixtures/literals_assign.py.uast
@@ -36,7 +36,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# int"
+.  .  .  .  .  .  .  TOKEN "[# int]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 5
 .  .  .  .  .  .  .  .  Line: 1
@@ -103,7 +103,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# float"
+.  .  .  .  .  .  .  TOKEN "[# float]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 20
 .  .  .  .  .  .  .  .  Line: 2
@@ -170,7 +170,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# string"
+.  .  .  .  .  .  .  TOKEN "[# string]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 45
 .  .  .  .  .  .  .  .  Line: 3
@@ -237,7 +237,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# None"
+.  .  .  .  .  .  .  TOKEN "[# None]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 63
 .  .  .  .  .  .  .  .  Line: 4
@@ -269,7 +269,6 @@ Module {
 .  .  .  .  .  }
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: value
-.  .  .  .  .  .  value: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  }
@@ -305,7 +304,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# list literal"
+.  .  .  .  .  .  .  TOKEN "[# list literal]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 84
 .  .  .  .  .  .  .  .  Line: 5
@@ -420,7 +419,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# tuple literal"
+.  .  .  .  .  .  .  TOKEN "[# tuple literal]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 113
 .  .  .  .  .  .  .  .  Line: 6
@@ -535,7 +534,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# set literal"
+.  .  .  .  .  .  .  TOKEN "[# set literal]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 143
 .  .  .  .  .  .  .  .  Line: 7
@@ -649,7 +648,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# dict literal"
+.  .  .  .  .  .  .  TOKEN "[# dict literal]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 178
 .  .  .  .  .  .  .  .  Line: 8
@@ -780,7 +779,7 @@ Module {
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  TOKEN "# expression assignment"
+.  .  .  .  .  .  .  TOKEN "[# expression assignment]"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 212
 .  .  .  .  .  .  .  .  Line: 9

--- a/fixtures/other_statements.py.uast
+++ b/fixtures/other_statements.py.uast
@@ -153,15 +153,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {

--- a/fixtures/pass.py.native
+++ b/fixtures/pass.py.native
@@ -18,7 +18,9 @@
                         "end_col_offset": 11,
                         "end_lineno": 1,
                         "lineno": 1,
-                        "noop_line": "# easy"
+                        "noop_line": [
+                            "# easy"
+                        ]
                     }
                 },
                 {
@@ -45,14 +47,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 2,
                                 "lineno": 2,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 2,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],
@@ -88,14 +83,7 @@
                                 "end_col_offset": 1,
                                 "end_lineno": 4,
                                 "lineno": 4,
-                                "lines": [
-                                    {
-                                        "ast_type": "NoopLine",
-                                        "col_offset": 1,
-                                        "lineno": 4,
-                                        "noop_line": "\n"
-                                    }
-                                ]
+                                "lines": []
                             }
                         }
                     ],

--- a/fixtures/pass.py.uast
+++ b/fixtures/pass.py.uast
@@ -24,7 +24,7 @@ Module {
 .  .  .  Children: {
 .  .  .  .  0: SameLineNoops {
 .  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# easy"
+.  .  .  .  .  TOKEN "[# easy]"
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 4
 .  .  .  .  .  .  Line: 1
@@ -56,15 +56,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {
@@ -88,7 +85,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 12
 .  .  .  .  .  .  .  .  .  .  Line: 2
@@ -101,21 +98,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 12
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 2
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -139,15 +121,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: FunctionDef.body {
@@ -171,7 +150,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 33
 .  .  .  .  .  .  .  .  .  .  Line: 4
@@ -184,21 +163,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 33
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 4
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }

--- a/fixtures/print.py.uast
+++ b/fixtures/print.py.uast
@@ -19,7 +19,6 @@ Module {
 .  .  .  .  Col: 5
 .  .  .  }
 .  .  .  Properties: {
-.  .  .  .  dest: <nil>
 .  .  .  .  internalRole: body
 .  .  .  .  nl: true
 .  .  .  }
@@ -57,7 +56,6 @@ Module {
 .  .  .  .  Col: 5
 .  .  .  }
 .  .  .  Properties: {
-.  .  .  .  dest: <nil>
 .  .  .  .  internalRole: body
 .  .  .  .  nl: true
 .  .  .  }

--- a/fixtures/sorting.py.native
+++ b/fixtures/sorting.py.native
@@ -31,7 +31,7 @@
                                         "ast_type": "NoopLine",
                                         "col_offset": 1,
                                         "lineno": 1,
-                                        "noop_line": "# before comment\n"
+                                        "noop_line": " before comment\n"
                                     }
                                 ]
                             },
@@ -41,7 +41,9 @@
                                 "end_col_offset": 26,
                                 "end_lineno": 2,
                                 "lineno": 2,
-                                "noop_line": "# linetrailing comment"
+                                "noop_line": [
+                                    "# linetrailing comment"
+                                ]
                             }
                         },
                         "lineno": 2,
@@ -70,7 +72,7 @@
                         "ast_type": "NoopLine",
                         "col_offset": 1,
                         "lineno": 3,
-                        "noop_line": "# remaining comment\n"
+                        "noop_line": " remaining comment\n"
                     }
                 ]
             }

--- a/fixtures/sorting.py.uast
+++ b/fixtures/sorting.py.uast
@@ -45,7 +45,7 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 0
 .  .  .  .  .  .  .  .  .  .  Line: 1
@@ -61,8 +61,8 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "# before comment
+.  .  .  .  .  .  .  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  .  .  .  .  .  .  TOKEN " before comment
 "
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 0
@@ -77,7 +77,7 @@ Module {
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: SameLineNoops {
 .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  TOKEN "# linetrailing comment"
+.  .  .  .  .  .  .  .  .  TOKEN "[# linetrailing comment]"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 20
 .  .  .  .  .  .  .  .  .  .  Line: 2
@@ -123,7 +123,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  1: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 44
 .  .  .  .  Line: 3
@@ -139,8 +139,8 @@ Module {
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "# remaining comment
+.  .  .  .  .  Roles: Noop,Comment
+.  .  .  .  .  TOKEN " remaining comment
 "
 .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  Offset: 44

--- a/fixtures/string_fstring.py.native
+++ b/fixtures/string_fstring.py.native
@@ -321,14 +321,7 @@
                                     "end_col_offset": 1,
                                     "end_lineno": 8,
                                     "lineno": 8,
-                                    "lines": [
-                                        {
-                                            "ast_type": "NoopLine",
-                                            "col_offset": 1,
-                                            "lineno": 8,
-                                            "noop_line": "\n"
-                                        }
-                                    ]
+                                    "lines": []
                                 }
                             }
                         ],
@@ -500,14 +493,7 @@
                 "end_col_offset": 1,
                 "end_lineno": 12,
                 "lineno": 12,
-                "lines": [
-                    {
-                        "ast_type": "NoopLine",
-                        "col_offset": 1,
-                        "lineno": 12,
-                        "noop_line": "\n"
-                    }
-                ]
+                "lines": []
             }
         }
     }

--- a/fixtures/string_fstring.py.uast
+++ b/fixtures/string_fstring.py.uast
@@ -150,7 +150,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  conversion: -1
-.  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
@@ -238,7 +237,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  conversion: 115
-.  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
@@ -326,7 +324,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  conversion: 114
-.  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
@@ -414,7 +411,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  conversion: 97
-.  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
@@ -525,7 +521,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  conversion: -1
-.  .  .  .  .  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
@@ -569,7 +564,6 @@ Module {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  conversion: -1
-.  .  .  .  .  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
@@ -640,15 +634,12 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: body
-.  .  .  .  returns: <nil>
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: arguments {
 .  .  .  .  .  Roles: Function,Declaration,Incomplete,Argument
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: args
-.  .  .  .  .  .  kwarg: <nil>
-.  .  .  .  .  .  vararg: <nil>
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: arg {
@@ -665,12 +656,11 @@ Module {
 .  .  .  .  .  .  .  .  Col: 14
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  annotation: <nil>
 .  .  .  .  .  .  .  .  internalRole: args
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PreviousNoops {
-.  .  .  .  .  .  .  .  .  Roles: Whitespace
+.  .  .  .  .  .  .  .  .  Roles: Noop
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 250
 .  .  .  .  .  .  .  .  .  .  Line: 8
@@ -683,21 +673,6 @@ Module {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: noops_previous
-.  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  Children: {
-.  .  .  .  .  .  .  .  .  .  0: NoopLine {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Comment
-.  .  .  .  .  .  .  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  .  .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  .  .  .  .  .  .  Offset: 250
-.  .  .  .  .  .  .  .  .  .  .  .  Line: 8
-.  .  .  .  .  .  .  .  .  .  .  .  Col: 1
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  .  Properties: {
-.  .  .  .  .  .  .  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  .  .  .  .  .  .  }
-.  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  }
@@ -833,7 +808,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  conversion: -1
-.  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
@@ -946,7 +920,6 @@ Module {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  conversion: -1
-.  .  .  .  .  .  .  .  format_spec: <nil>
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
@@ -1014,7 +987,7 @@ Module {
 .  .  .  }
 .  .  }
 .  .  10: RemainderNoops {
-.  .  .  Roles: Whitespace
+.  .  .  Roles: Noop
 .  .  .  StartPosition: {
 .  .  .  .  Offset: 0
 .  .  .  .  Line: 12
@@ -1027,21 +1000,6 @@ Module {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: noops_remainder
-.  .  .  }
-.  .  .  Children: {
-.  .  .  .  0: NoopLine {
-.  .  .  .  .  Roles: Comment
-.  .  .  .  .  TOKEN "
-"
-.  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 0
-.  .  .  .  .  .  Line: 12
-.  .  .  .  .  .  Col: 1
-.  .  .  .  .  }
-.  .  .  .  .  Properties: {
-.  .  .  .  .  .  internalRole: lines
-.  .  .  .  .  }
-.  .  .  .  }
 .  .  .  }
 .  .  }
 .  }

--- a/native/python_package/python_driver/astimprove.py
+++ b/native/python_package/python_driver/astimprove.py
@@ -212,12 +212,16 @@ class NoopExtractor(object):
             nooplines: List[Node] = []
             curline = startline
             for noopline in noops_previous:
-                nooplines.append({
-                    "ast_type": "NoopLine",
-                    "noop_line": noopline,
-                    "lineno": curline,
-                    "col_offset": 1,
-                })
+                if noopline != '\n':
+                    if noopline.lstrip().startswith('#'):
+                        noopline = noopline.lstrip()[1:]
+
+                    nooplines.append({
+                        "ast_type": "NoopLine",
+                        "noop_line": noopline,
+                        "lineno": curline,
+                        "col_offset": 1,
+                    })
                 curline += 1
             return nooplines
 
@@ -237,7 +241,13 @@ class NoopExtractor(object):
         # Other noops at the end of its significative line except the implicit
         # finishing newline
         noops_sameline: List[Token] = [i for i in self.sameline_remainder_noops(node) if i]
-        joined_sameline = ''.join([tok.value for tok in noops_sameline])
+
+        joined_sameline = []
+        for tok in noops_sameline:
+            if tok.value.lstrip().startswith('\n'):
+                joined_sameline.append(tok.value.lstrip()[1:])
+            else:
+                joined_sameline.append(tok.value)
 
         if noops_sameline:
             node['noops_sameline'] = {

--- a/native/python_package/test/typecheck.sh
+++ b/native/python_package/test/typecheck.sh
@@ -2,4 +2,4 @@
 # call this from the parent directory
 mypy --ignore-missing-imports --follow-imports silent --disallow-untyped-calls \
     --disallow-untyped-defs --check-untyped-defs --warn-unused-ignores \
-    --strict-optional --python-versio 3.6 python_driver/*.py
+    --strict-optional python_driver/*.py


### PR DESCRIPTION
- Remove `#` at the start of comment tokens, fixes #147.
- Remove empty white lines nodes.