### PR TITLE
Correctly handle python2 kwargs

### DIFF
--- a/driver/normalizer/normalizer.go
+++ b/driver/normalizer/normalizer.go
@@ -88,8 +88,8 @@ func mapStr(nativeType string) Mapping {
 			{Name: uast.KeyType, Op: String("Boxed" + nativeType)},
 			{Name: "boxed_value", Op: UASTType(uast.String{}, Obj{
 				uast.KeyPos: Var("pos_"),
-				"Value": Var("s"),
-				"Format": String(""),
+				"Value":     Var("s"),
+				//"Format":    String(""),
 			})},
 			{Name: "noops_previous", Optional: "np_opt", Op: Var("noops_previous")},
 			{Name: "noops_sameline", Optional: "ns_opt", Op: Var("noops_sameline")},
@@ -114,7 +114,7 @@ var Normalizers = []Mapping{
 			{Name: uast.KeyType, Op: String("BoxedName")},
 			{Name: "boxed_value", Op: UASTType(uast.Identifier{}, Obj{
 				uast.KeyPos: Var("pos_"),
-				"Name": Var("id"),
+				"Name":      Var("id"),
 			})},
 			{Name: "noops_previous", Optional: "np_opt", Op: Var("noops_previous")},
 			{Name: "noops_sameline", Optional: "ns_opt", Op: Var("noops_sameline")},
@@ -136,7 +136,7 @@ var Normalizers = []Mapping{
 			{Name: uast.KeyType, Op: String("BoxedBoolLiteral")},
 			{Name: "boxed_value", Op: UASTType(uast.Bool{}, Obj{
 				uast.KeyPos: Var("pos_"),
-				"Value": Var("lv"),
+				"Value":     Var("lv"),
 			})},
 			{Name: "noops_previous", Optional: "np_opt", Op: Var("noops_previous")},
 			{Name: "noops_sameline", Optional: "ns_opt", Op: Var("noops_sameline")},
@@ -225,8 +225,8 @@ var Normalizers = []Mapping{
 			uast.KeyToken: Var("name"),
 		},
 		Obj{
-			"Name":        identifierWithPos("name"),
-			"MapVariadic": Bool(true),
+			"Name": identifierWithPos("name"),
+		    "MapVariadic": Bool(true),
 		},
 	)),
 

--- a/native/python_package/python_driver/astimprove.py
+++ b/native/python_package/python_driver/astimprove.py
@@ -221,7 +221,15 @@ class AstImprover():
             if isinstance(kwarg, str):
                 # Python2 kwargs are just strings; convert to same format
                 # as Python3
-                kwarg = {"arg": kwarg, "annotation": None}
+                kwarg = {
+                    "arg": kwarg,
+                    "annotation": None,
+                    # the tokenizer will fix the positions later
+                    "lineno": 1,
+                    "end_lineno": 1,
+                    "col_offset": 0,
+                    "end_col_offset": 0
+                    }
             kwarg["ast_type"] = "kwarg"
             norm_args.append(self.visit(kwarg))
 
@@ -275,6 +283,7 @@ if __name__ == '__main__':
         version = codeinfo['version']
 
         failed = False
+        testdict = None
 
         if version in (3, 6) and codeinfo['py3ast']:
             testdict = codeinfo['py3ast']["PY3AST"]


### PR DESCRIPTION
- Correctly handle python2 args which on the python2 AST are just strings.
- Improve the __main__ testing/debug code.

Fixes #177

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>