### PR TITLE
Remove Then role from loop bodies

### DIFF
--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -76,7 +76,7 @@ func loopAnnotate(typ string, mainRole role.Role, roles ...role.Role) Mapping {
 	}, Obj{
 		"body": Obj{
 			uast.KeyType:  String("For.body"),
-			uast.KeyRoles: Roles(mainRole, role.Body, role.Then),
+			uast.KeyRoles: Roles(mainRole, role.Body),
 			"body_stmts":  Var("body_stmts"),
 		},
 		"orelse": Obj{
@@ -423,7 +423,7 @@ var Annotations = []Mapping{
 		"decorator_list": Var("decors"),
 		"body":           Var("body_stmts"),
 		"bases":          Var("bases"),
-		"name": Var("name"),
+		"name":           Var("name"),
 	}, Obj{
 		uast.KeyToken: Var("name"),
 		"decorator_list": Obj{

--- a/fixtures/bench_binary_search.py.sem.uast
+++ b/fixtures/bench_binary_search.py.sem.uast
@@ -206,7 +206,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "python:Assign",
                                     '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_binary_search.py.uast
+++ b/fixtures/bench_binary_search.py.uast
@@ -231,7 +231,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, Then, While],
+                     '@role': [Body, While],
                      'body_stmts': [
                         { '@type': "Assign",
                            '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_ethopian_multiplication.py.sem.uast
+++ b/fixtures/bench_ethopian_multiplication.py.sem.uast
@@ -132,7 +132,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "python:Expr",
                                     '@role': [Expression],
@@ -1187,7 +1187,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:Print",
                                     '@token': "print",

--- a/fixtures/bench_ethopian_multiplication.py.uast
+++ b/fixtures/bench_ethopian_multiplication.py.uast
@@ -205,7 +205,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, Then, While],
+                     '@role': [Body, While],
                      'body_stmts': [
                         { '@type': "Expr",
                            '@role': [Expression],
@@ -1130,7 +1130,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "Print",
                            '@token': "print",

--- a/fixtures/bench_fizzbuzz.py.sem.uast
+++ b/fixtures/bench_fizzbuzz.py.sem.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "python:For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "python:If",
                   '@token': "if",

--- a/fixtures/bench_fizzbuzz.py.uast
+++ b/fixtures/bench_fizzbuzz.py.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "If",
                   '@token': "if",

--- a/fixtures/bench_gcd.py.sem.uast
+++ b/fixtures/bench_gcd.py.sem.uast
@@ -680,7 +680,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "python:AugAssign",
                                     '@role': [Assignment, Binary, Expression, Operator],
@@ -1251,7 +1251,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "python:While",
                                     '@token': "while",
@@ -1269,7 +1269,7 @@
                                        },
                                     },
                                     body: { '@type': "python:For.body",
-                                       '@role': [Body, Then, While],
+                                       '@role': [Body, While],
                                        'body_stmts': [
                                           { '@type': "python:AugAssign",
                                              '@role': [Assignment, Binary, Expression, Operator],

--- a/fixtures/bench_gcd.py.uast
+++ b/fixtures/bench_gcd.py.uast
@@ -673,7 +673,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, Then, While],
+                     '@role': [Body, While],
                      'body_stmts': [
                         { '@type': "AugAssign",
                            '@role': [Assignment, Binary, Expression, Operator],
@@ -1223,7 +1223,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, Then, While],
+                     '@role': [Body, While],
                      'body_stmts': [
                         { '@type': "While",
                            '@token': "while",
@@ -1241,7 +1241,7 @@
                               },
                            },
                            body: { '@type': "For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "AugAssign",
                                     '@role': [Assignment, Binary, Expression, Operator],

--- a/fixtures/bench_happy_numbers.py.sem.uast
+++ b/fixtures/bench_happy_numbers.py.sem.uast
@@ -107,7 +107,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "python:Assign",
                                     '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_happy_numbers.py.uast
+++ b/fixtures/bench_happy_numbers.py.uast
@@ -119,7 +119,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, Then, While],
+                     '@role': [Body, While],
                      'body_stmts': [
                         { '@type': "Assign",
                            '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_hundred_doors.py.sem.uast
+++ b/fixtures/bench_hundred_doors.py.sem.uast
@@ -114,7 +114,7 @@
             },
          },
          body: { '@type': "python:For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "python:For",
                   '@token': "for",
@@ -132,7 +132,7 @@
                      },
                   },
                   body: { '@type': "python:For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "python:Assign",
                            '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_hundred_doors.py.uast
+++ b/fixtures/bench_hundred_doors.py.uast
@@ -110,7 +110,7 @@
             },
          },
          body: { '@type': "For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "For",
                   '@token': "for",
@@ -128,7 +128,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "Assign",
                            '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_is_prime.py.sem.uast
+++ b/fixtures/bench_is_prime.py.sem.uast
@@ -891,7 +891,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "python:If",
                                     '@token': "if",

--- a/fixtures/bench_is_prime.py.uast
+++ b/fixtures/bench_is_prime.py.uast
@@ -877,7 +877,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, Then, While],
+                     '@role': [Body, While],
                      'body_stmts': [
                         { '@type': "If",
                            '@token': "if",

--- a/fixtures/bench_n_queens.py.sem.uast
+++ b/fixtures/bench_n_queens.py.sem.uast
@@ -610,7 +610,7 @@
                                                          },
                                                       },
                                                       body: { '@type': "python:For.body",
-                                                         '@role': [Body, For, Then],
+                                                         '@role': [Body, For],
                                                          'body_stmts': [
                                                             { '@type': "python:Assign",
                                                                '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_n_queens.py.uast
+++ b/fixtures/bench_n_queens.py.uast
@@ -618,7 +618,7 @@
                                        },
                                     },
                                     body: { '@type': "For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "Assign",
                                              '@role': [Assignment, Binary, Expression],

--- a/fixtures/bench_power_set.py.sem.uast
+++ b/fixtures/bench_power_set.py.sem.uast
@@ -133,7 +133,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:Expr",
                                     '@role': [Expression],

--- a/fixtures/bench_power_set.py.uast
+++ b/fixtures/bench_power_set.py.uast
@@ -143,7 +143,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "Expr",
                            '@role': [Expression],

--- a/fixtures/continue_break.py.sem.uast
+++ b/fixtures/continue_break.py.sem.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "python:For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "python:If",
                   '@token': "if",

--- a/fixtures/continue_break.py.uast
+++ b/fixtures/continue_break.py.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "If",
                   '@token': "if",

--- a/fixtures/for.py.sem.uast
+++ b/fixtures/for.py.sem.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "python:For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "python:AugAssign",
                   '@role': [Assignment, Binary, Expression, Operator],

--- a/fixtures/for.py.uast
+++ b/fixtures/for.py.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "AugAssign",
                   '@role': [Assignment, Binary, Expression, Operator],

--- a/fixtures/issue62_b.py.sem.uast
+++ b/fixtures/issue62_b.py.sem.uast
@@ -355,7 +355,7 @@
                                        },
                                     },
                                     body: { '@type': "python:For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "python:If",
                                              '@token': "if",
@@ -951,7 +951,7 @@
                                        },
                                     },
                                     body: { '@type': "python:For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "python:Expr",
                                              '@role': [Expression],

--- a/fixtures/issue62_b.py.uast
+++ b/fixtures/issue62_b.py.uast
@@ -453,7 +453,7 @@
                               },
                            },
                            body: { '@type': "For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "If",
                                     '@token': "if",
@@ -963,7 +963,7 @@
                               },
                            },
                            body: { '@type': "For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "Expr",
                                     '@role': [Expression],

--- a/fixtures/issue_server101.py.sem.uast
+++ b/fixtures/issue_server101.py.sem.uast
@@ -11601,7 +11601,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:If",
                                     '@token': "if",
@@ -16543,7 +16543,7 @@
                                                 },
                                              },
                                              body: { '@type': "python:For.body",
-                                                '@role': [Body, For, Then],
+                                                '@role': [Body, For],
                                                 'body_stmts': [
                                                    { '@type': "python:Assign",
                                                       '@role': [Assignment, Binary, Expression],
@@ -17005,7 +17005,7 @@
                                                 },
                                              },
                                              body: { '@type': "python:For.body",
-                                                '@role': [Body, For, Then],
+                                                '@role': [Body, For],
                                                 'body_stmts': [
                                                    { '@type': "python:If",
                                                       '@token': "if",
@@ -18153,7 +18153,7 @@
                                        },
                                     },
                                     body: { '@type': "python:For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "python:If",
                                              '@token': "if",
@@ -21679,7 +21679,7 @@
                                                 },
                                              },
                                              body: { '@type': "python:For.body",
-                                                '@role': [Body, For, Then],
+                                                '@role': [Body, For],
                                                 'body_stmts': [
                                                    { '@type': "python:Assign",
                                                       '@role': [Assignment, Binary, Expression],
@@ -34845,7 +34845,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:TryExcept",
                                     '@role': [Catch, Statement, Try],
@@ -37908,7 +37908,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:If",
                                     '@token': "if",
@@ -39100,7 +39100,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:If",
                                     '@token': "if",
@@ -42587,7 +42587,7 @@
                                        },
                                     },
                                     body: { '@type': "python:For.body",
-                                       '@role': [Body, Then, While],
+                                       '@role': [Body, While],
                                        'body_stmts': [
                                           { '@type': "python:Assign",
                                              '@role': [Assignment, Binary, Expression],
@@ -43297,7 +43297,7 @@
                                        },
                                     },
                                     body: { '@type': "python:For.body",
-                                       '@role': [Body, Then, While],
+                                       '@role': [Body, While],
                                        'body_stmts': [
                                           { '@type': "python:Assign",
                                              '@role': [Assignment, Binary, Expression],
@@ -46266,7 +46266,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:TryExcept",
                                     '@role': [Catch, Statement, Try],
@@ -47261,7 +47261,7 @@
                               },
                            },
                            body: { '@type': "python:For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "python:TryExcept",
                                     '@role': [Catch, Statement, Try],
@@ -51643,7 +51643,7 @@
                                              },
                                           },
                                           body: { '@type': "python:For.body",
-                                             '@role': [Body, For, Then],
+                                             '@role': [Body, For],
                                              'body_stmts': [
                                                 { '@type': "python:If",
                                                    '@token': "if",

--- a/fixtures/issue_server101.py.uast
+++ b/fixtures/issue_server101.py.uast
@@ -11027,7 +11027,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "If",
                            '@token': "if",
@@ -15463,7 +15463,7 @@
                                        },
                                     },
                                     body: { '@type': "For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "Assign",
                                              '@role': [Assignment, Binary, Expression],
@@ -15900,7 +15900,7 @@
                                        },
                                     },
                                     body: { '@type': "For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "If",
                                              '@token': "if",
@@ -16965,7 +16965,7 @@
                               },
                            },
                            body: { '@type': "For.body",
-                              '@role': [Body, For, Then],
+                              '@role': [Body, For],
                               'body_stmts': [
                                  { '@type': "If",
                                     '@token': "if",
@@ -20258,7 +20258,7 @@
                                        },
                                     },
                                     body: { '@type': "For.body",
-                                       '@role': [Body, For, Then],
+                                       '@role': [Body, For],
                                        'body_stmts': [
                                           { '@type': "Assign",
                                              '@role': [Assignment, Binary, Expression],
@@ -32335,7 +32335,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "TryExcept",
                            '@role': [Catch, Statement, Try],
@@ -35213,7 +35213,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "If",
                            '@token': "if",
@@ -36273,7 +36273,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "If",
                            '@token': "if",
@@ -39553,7 +39553,7 @@
                               },
                            },
                            body: { '@type': "For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "Assign",
                                     '@role': [Assignment, Binary, Expression],
@@ -40200,7 +40200,7 @@
                               },
                            },
                            body: { '@type': "For.body",
-                              '@role': [Body, Then, While],
+                              '@role': [Body, While],
                               'body_stmts': [
                                  { '@type': "Assign",
                                     '@role': [Assignment, Binary, Expression],
@@ -42911,7 +42911,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "TryExcept",
                            '@role': [Catch, Statement, Try],
@@ -43801,7 +43801,7 @@
                      },
                   },
                   body: { '@type': "For.body",
-                     '@role': [Body, For, Then],
+                     '@role': [Body, For],
                      'body_stmts': [
                         { '@type': "TryExcept",
                            '@role': [Catch, Statement, Try],
@@ -47847,7 +47847,7 @@
                                     },
                                  },
                                  body: { '@type': "For.body",
-                                    '@role': [Body, For, Then],
+                                    '@role': [Body, For],
                                     'body_stmts': [
                                        { '@type': "If",
                                           '@token': "if",

--- a/fixtures/loop_if.py.sem.uast
+++ b/fixtures/loop_if.py.sem.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "python:For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "python:Pass",
                   '@token': "pass",

--- a/fixtures/loop_if.py.uast
+++ b/fixtures/loop_if.py.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "For.body",
-            '@role': [Body, For, Then],
+            '@role': [Body, For],
             'body_stmts': [
                { '@type': "Pass",
                   '@token': "pass",

--- a/fixtures/while.py.sem.uast
+++ b/fixtures/while.py.sem.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "python:For.body",
-            '@role': [Body, Then, While],
+            '@role': [Body, While],
             'body_stmts': [
                { '@type': "python:Expr",
                   '@role': [Expression],

--- a/fixtures/while.py.uast
+++ b/fixtures/while.py.uast
@@ -19,7 +19,7 @@
             },
          },
          body: { '@type': "For.body",
-            '@role': [Body, Then, While],
+            '@role': [Body, While],
             'body_stmts': [
                { '@type': "Expr",
                   '@role': [Expression],


### PR DESCRIPTION
Python appears to be the only driver that adds a `Then` role to the loop body. Remove the role for consistency.

Fixes #193

Signed-off-by: Denys Smirnov <denys@sourced.tech>